### PR TITLE
ci: auto-add issues and PRs to org project board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,15 @@
+name: Add to project board
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/wyre-technology/projects/1
+          github-token: ${{ secrets.ADD_TO_PROJECT_TOKEN }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically adds new issues and PRs to the [MSP Claude Plugins project board](https://github.com/orgs/wyre-technology/projects/1).