### PR TITLE
feat: add ticket and project ticket notes tools

### DIFF
--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -36,6 +36,94 @@ export function registerProjectTools(server: McpServer, client: CwManageClient) 
   );
 
   server.tool(
+    "cw_search_project_tickets",
+    "Search tickets under a project. Use projectId to filter by project, or conditions for CW query syntax.",
+    {
+      projectId: z.number().optional().describe("Filter by project ID"),
+      conditions: z.string().optional().describe("ConnectWise conditions query string"),
+      page: z.number().optional().describe("Page number (default: 1)"),
+      pageSize: z.number().optional().describe("Results per page (default: 25, max: 1000)"),
+      orderBy: z.string().optional().describe("Field to order by (e.g. 'id desc')"),
+    },
+    async ({ projectId, conditions, page, pageSize, orderBy }) => {
+      const conditionParts: string[] = [];
+      if (projectId !== undefined) conditionParts.push(`project/id=${projectId}`);
+      if (conditions) conditionParts.push(conditions);
+
+      const result = await client.get("/project/tickets", {
+        conditions: conditionParts.join(" and ") || undefined,
+        page: page ?? 1,
+        pageSize: pageSize ?? 25,
+        orderBy,
+      });
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "cw_get_project_ticket",
+    "Get a specific project ticket by ID.",
+    {
+      id: z.number().describe("Project ticket ID"),
+    },
+    async ({ id }) => {
+      const result = await client.get(`/project/tickets/${id}`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "cw_get_project_ticket_notes",
+    "Get all notes on a project ticket, including notes from any child tickets.",
+    {
+      id: z.number().describe("Project ticket ID"),
+      page: z.number().optional().describe("Page number (default: 1)"),
+      pageSize: z.number().optional().describe("Results per page (default: 25, max: 1000)"),
+    },
+    async ({ id, page, pageSize }) => {
+      try {
+        const result = await client.get(`/project/tickets/${id}/allNotes`, {
+          page: page ?? 1,
+          pageSize: pageSize ?? 25,
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("404") || msg.includes("405")) {
+          // allNotes not supported on this CWM version — fall back to /notes
+          const result = await client.get(`/project/tickets/${id}/notes`, {
+            page: page ?? 1,
+            pageSize: pageSize ?? 25,
+          });
+          return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        }
+        throw err;
+      }
+    },
+  );
+
+  server.tool(
+    "cw_add_project_ticket_note",
+    "Add a note to a project ticket. Use internalAnalysisFlag for internal-only notes or resolutionFlag for resolution notes. Defaults to a plain discussion note.",
+    {
+      id: z.number().describe("Project ticket ID"),
+      text: z.string().describe("Note text content"),
+      detailDescriptionFlag: z.boolean().optional().describe("Add as detail description (default: false)"),
+      internalAnalysisFlag: z.boolean().optional().describe("Mark as internal analysis only (default: false)"),
+      resolutionFlag: z.boolean().optional().describe("Mark as resolution note (default: false)"),
+    },
+    async ({ id, text, detailDescriptionFlag, internalAnalysisFlag, resolutionFlag }) => {
+      const body: Record<string, unknown> = { text };
+      if (detailDescriptionFlag !== undefined) body.detailDescriptionFlag = detailDescriptionFlag;
+      if (internalAnalysisFlag !== undefined) body.internalAnalysisFlag = internalAnalysisFlag;
+      if (resolutionFlag !== undefined) body.resolutionFlag = resolutionFlag;
+
+      const result = await client.post(`/project/tickets/${id}/notes`, body);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
     "cw_create_project",
     "Create a new project.",
     {

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -94,4 +94,57 @@ export function registerTicketTools(server: McpServer, client: CwManageClient) {
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
     },
   );
+
+  server.tool(
+    "cw_get_ticket_notes",
+    "Get all notes/discussions on a service ticket, including notes from any child tickets.",
+    {
+      id: z.number().describe("Ticket ID"),
+      page: z.number().optional().describe("Page number (default: 1)"),
+      pageSize: z.number().optional().describe("Results per page (default: 25, max: 1000)"),
+    },
+    async ({ id, page, pageSize }) => {
+      try {
+        const result = await client.get(`/service/tickets/${id}/allNotes`, {
+          page: page ?? 1,
+          pageSize: pageSize ?? 25,
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("404") || msg.includes("405")) {
+          // allNotes not supported on this CWM version — fall back to /notes
+          const result = await client.get(`/service/tickets/${id}/notes`, {
+            page: page ?? 1,
+            pageSize: pageSize ?? 25,
+          });
+          return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        }
+        throw err;
+      }
+    },
+  );
+
+  server.tool(
+    "cw_add_ticket_note",
+    "Add a note to a service ticket. Use detailDescriptionFlag for a description note, internalAnalysisFlag for an internal-only note, or resolutionFlag for a resolution note. Defaults to a plain discussion note visible to the customer.",
+    {
+      id: z.number().describe("Ticket ID"),
+      text: z.string().describe("Note text content"),
+      detailDescriptionFlag: z.boolean().optional().describe("Add as detail description (default: false)"),
+      internalAnalysisFlag: z.boolean().optional().describe("Mark as internal analysis only (default: false)"),
+      resolutionFlag: z.boolean().optional().describe("Mark as resolution note (default: false)"),
+      customerUpdatedFlag: z.boolean().optional().describe("Flag that the customer was updated (default: false)"),
+    },
+    async ({ id, text, detailDescriptionFlag, internalAnalysisFlag, resolutionFlag, customerUpdatedFlag }) => {
+      const body: Record<string, unknown> = { text };
+      if (detailDescriptionFlag !== undefined) body.detailDescriptionFlag = detailDescriptionFlag;
+      if (internalAnalysisFlag !== undefined) body.internalAnalysisFlag = internalAnalysisFlag;
+      if (resolutionFlag !== undefined) body.resolutionFlag = resolutionFlag;
+      if (customerUpdatedFlag !== undefined) body.customerUpdatedFlag = customerUpdatedFlag;
+
+      const result = await client.post(`/service/tickets/${id}/notes`, body);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
 }


### PR DESCRIPTION
## Summary

- Adds `cw_get_ticket_notes` and `cw_add_ticket_note` for service tickets (includes notes from child tickets via `/allNotes`)
- Adds `cw_search_project_tickets`, `cw_get_project_ticket`, `cw_get_project_ticket_notes`, and `cw_add_project_ticket_note` for project tickets
- Falls back to `/notes` on 404/405 for older ConnectWise Manage versions that do not support `/allNotes`


