### PR TITLE
feat: add Entra ID OAuth 2.1 authentication layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,85 @@
+# =============================================================================
+# ConnectWise Manage — API Credentials
+# =============================================================================
+
+# Your ConnectWise company identifier (the short name used to log in)
+CW_MANAGE_COMPANY_ID=yourcompany
+
+# API member public/private key pair (create under Members > API Members in CWM)
+CW_MANAGE_PUBLIC_KEY=
+CW_MANAGE_PRIVATE_KEY=
+
+# Client ID from the ConnectWise Developer Portal (developer.connectwise.com)
+CW_MANAGE_CLIENT_ID=
+
+# API base URL — choose the region that matches your CWM instance
+# Cloud NA (default): https://api-na.myconnectwise.net
+# Cloud EU:           https://api-eu.myconnectwise.net
+# Cloud AU:           https://api-au.myconnectwise.net
+# Self-hosted:        https://cwm.yourcompany.com
+CW_MANAGE_URL=https://api-na.myconnectwise.net
+
+# Set to "false" only for self-hosted instances with self-signed TLS certs
+CW_MANAGE_REJECT_UNAUTHORIZED=true
+
+# =============================================================================
+# MCP Server
+# =============================================================================
+
+MCP_TRANSPORT=http
+MCP_HTTP_PORT=8080
+MCP_HTTP_HOST=0.0.0.0
+
+# Authentication mode:
+#   env     - CW credentials are read from environment variables above (default)
+#   gateway - CW credentials are passed per-request via X-CW-* headers
+AUTH_MODE=env
+
+# =============================================================================
+# Entra ID OAuth 2.1  (for Claude.ai web — set MCP_OAUTH_ENABLED=true)
+# =============================================================================
+# Before filling these in, create the Azure AD app registration:
+#   - Platform: Mobile and desktop applications
+#   - Redirect URI: https://claude.ai/api/mcp/auth_callback
+#   - Allow public client flows: Yes
+#   - Manifest: add "accessTokenAcceptedVersion": 2
+#   - Expose an API: App ID URI api://<client-id>, scope: access_as_user
+#   - App Role: CWM.Access (assign to staff group)
+
+MCP_OAUTH_ENABLED=false
+
+# Full public URL of this server — no trailing slash
+MCP_SERVER_URL=https://mcp.yourdomain.com
+
+AZURE_TENANT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+AZURE_CLIENT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+AZURE_AUDIENCE=api://xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+
+# App role claim that must be present in every token (default: CWM.Access)
+AZURE_REQUIRED_ROLE=CWM.Access
+
+# =============================================================================
+# Static Bearer Token  (for Claude Code CLI / Claude Desktop)
+# =============================================================================
+# Generate a secure token: openssl rand -hex 32
+# Use in Claude Code CLI:
+#   claude mcp add --transport http cwm https://mcp.yourdomain.com/mcp \
+#     --header "Authorization: Bearer <token>"
+MCP_BEARER_TOKEN=
+
+# =============================================================================
+# Caddy (docker-compose.caddy.yml only)
+# =============================================================================
+
+# Public domain for TLS cert (must have a DNS A record pointing to this server)
+MCP_HOSTNAME=mcp.yourdomain.com
+
+# Email for Let's Encrypt registration
+ACME_EMAIL=you@yourdomain.com
+
+# =============================================================================
+# Logging
+# =============================================================================
+
+LOG_LEVEL=info
+NODE_ENV=production

--- a/AZURE_ACA_DEPLOYMENT.md
+++ b/AZURE_ACA_DEPLOYMENT.md
@@ -1,0 +1,892 @@
+# ConnectWise Manage MCP — Azure Container Apps Deployment Guide
+
+**OAuth 2.1 + Entra ID · All secrets in Key Vault · Claude.ai web + Claude Code CLI**
+
+---
+
+## What This Guide Covers
+
+This guide deploys the ConnectWise Manage MCP server to **Azure Container Apps (ACA)** using:
+
+- **OAuth 2.1 with Entra ID** — Claude.ai web authenticates via your Azure AD tenant. No shared bearer tokens.
+- **Key Vault for all config** — every environment variable, including static values, lives in Key Vault. Nothing is hardcoded or stored in shell history.
+- **Managed Identity** — the Container App pulls secrets from Key Vault and images from ACR with no stored credentials.
+- **Log Analytics** — all container logs stream automatically to Azure Monitor.
+
+Two image paths are documented. Choose the one that fits your situation:
+
+| Path | When to use |
+|---|---|
+| **A — With ACR** | You are running a fork with custom changes |
+| **B — Without ACR** | You are deploying the upstream image from GHCR |
+
+Both paths converge at Phase 7. Only the image reference differs.
+
+### What This Guide Does NOT Cover
+
+- **STDIO / Claude Desktop** — Claude Desktop uses the `stdio` transport and does not need a hosted server. See `README.md` for Claude Desktop setup.
+- **GitHub Actions CI/CD** — image builds are manual in this guide. Automating pushes to ACR via GitHub Actions is straightforward once the infrastructure is in place.
+
+---
+
+## Architecture
+
+```
+Claude.ai (web)
+     │
+     │  HTTPS  ← ACA provides TLS automatically, no Caddy needed
+     ▼
+Azure Container Apps (external ingress, port 8080)
+  {app}.{env}.{region}.azurecontainerapps.io  (or your custom domain)
+     │
+     ├── GET  /.well-known/oauth-protected-resource   ← RFC 9728
+     ├── GET  /.well-known/oauth-authorization-server ← RFC 8414
+     ├── POST /register                               ← RFC 7591
+     ├── GET  /authorize  → proxies to Entra ID
+     ├── POST /token      → proxies to Entra ID
+     ├── GET  /health
+     └── POST /mcp        ← MCP JSON-RPC (JWT-validated)
+          │
+          ▼
+     Key Vault (all secrets via Managed Identity)
+          │
+          ▼
+     ConnectWise Manage REST API
+```
+
+**Why no Caddy?** ACA terminates TLS and provides HTTPS automatically via a managed certificate on every app. Caddy is only needed for self-hosted deployments where you manage your own reverse proxy.
+
+---
+
+## Prerequisites
+
+- **Azure CLI** installed and logged in (`az login`)
+- **Docker Desktop** running (Path A only)
+- **Entra ID app registration** completed — follow [`entra-app-registration.md`](entra-app-registration.md) before continuing. You need:
+  - `AZURE_CLIENT_ID` (Application ID)
+  - `AZURE_TENANT_ID` (Directory ID)
+  - Redirect URI `https://claude.ai/api/mcp/auth_callback` registered under **Mobile and desktop applications**
+  - `accessTokenAcceptedVersion: 2` set in the app manifest
+  - API scope `api://<client-id>/access_as_user` created
+  - App role `CWM.Access` created and assigned to the relevant users or groups
+
+```powershell
+# Verify you're logged in to the right subscription
+az account show
+az account set --subscription "YOUR_SUBSCRIPTION_NAME_OR_ID"
+```
+
+---
+
+## Variables
+
+Set these once. Every subsequent command references them — no copy-pasting GUIDs.
+
+```powershell
+# === Customize these ===
+$RESOURCE_GROUP       = "rg-cwm-mcp"
+$LOCATION             = "eastus"           # eastus, eastus2, westus2, etc.
+$KEYVAULT_NAME        = "kv-cwm-mcp"       # Globally unique, 3-24 chars
+$ACA_ENV_NAME         = "aca-env-cwm"
+$ACA_APP_NAME         = "connectwise-manage-mcp"
+$IDENTITY_NAME        = "id-cwm-mcp"
+$LAW_NAME             = "law-cwm-mcp"      # Log Analytics workspace
+
+# === Path A only (fork / custom build) ===
+$ACR_NAME             = "acrcwmmcp"        # Globally unique, alphanumeric only, 5-50 chars
+
+# === From your Entra ID app registration (entra-app-registration.md) ===
+$AZURE_TENANT_ID      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+$AZURE_CLIENT_ID      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+$AZURE_AUDIENCE       = "api://$AZURE_CLIENT_ID"
+
+# === ConnectWise Manage API credentials ===
+# Company ID: the short identifier you use to log in to CWM
+# Public/private key: create under Members > API Members in CWM
+# Client ID: register at developer.connectwise.com
+$CW_COMPANY_ID        = "yourcompany"
+$CW_PUBLIC_KEY        = ""
+$CW_PRIVATE_KEY       = ""
+$CW_CLIENT_ID         = ""
+
+# CWM API base URL — choose the region that matches your instance:
+#   Cloud NA (default): https://api-na.myconnectwise.net
+#   Cloud EU:           https://api-eu.myconnectwise.net
+#   Cloud AU:           https://api-au.myconnectwise.net
+#   Self-hosted:        https://cwm.yourcompany.com
+$CW_URL               = "https://api-na.myconnectwise.net"
+
+# Set to "false" only for self-hosted instances with self-signed TLS certs
+$CW_REJECT_UNAUTHORIZED = "true"
+
+# === Optional: static bearer token for Claude Code CLI ===
+# Generate with: openssl rand -hex 32
+# Leave empty ("") to disable CLI token auth and use OAuth only
+$MCP_BEARER_TOKEN     = ""
+```
+
+> **Note:** `$AZURE_AUDIENCE` is constructed from `$AZURE_CLIENT_ID`. If token validation fails later, check the server logs for the actual `aud` claim and set this to match exactly.
+
+---
+
+## Phase 1 — Azure AD Pre-check
+
+Before deploying infrastructure, confirm your app registration is correctly configured. A misconfigured registration is the most common cause of OAuth failures.
+
+```powershell
+# Verify the app registration exists
+az ad app show --id $AZURE_CLIENT_ID --query "{name:displayName, id:appId}" --output table
+
+# Confirm redirect URI is under Mobile/Desktop (not SPA or Web)
+# Expected: ["https://claude.ai/api/mcp/auth_callback"]
+az ad app show --id $AZURE_CLIENT_ID --query "publicClient.redirectUris" --output json
+
+# Confirm the CWM.Access app role exists
+az ad app show --id $AZURE_CLIENT_ID --query "appRoles[?value=='CWM.Access'].{name:displayName,value:value,enabled:isEnabled}" --output table
+
+# Confirm accessTokenAcceptedVersion is 2 in the manifest
+# Check in the portal: App Registration → Manifest → "accessTokenAcceptedVersion": 2
+# If it reads null or 1, update it before proceeding.
+```
+
+**Expected redirect URI output:**
+```json
+[
+  "https://claude.ai/api/mcp/auth_callback"
+]
+```
+
+If anything is missing, complete the steps in [`entra-app-registration.md`](entra-app-registration.md) before continuing.
+
+---
+
+## Phase 2 — Resource Group and Key Vault
+
+```powershell
+# --- Resource Group ---
+az group create `
+  --name $RESOURCE_GROUP `
+  --location $LOCATION
+
+# --- Key Vault ---
+# enable-rbac-authorization true: use Azure RBAC instead of legacy access policies.
+az keyvault create `
+  --name $KEYVAULT_NAME `
+  --resource-group $RESOURCE_GROUP `
+  --location $LOCATION `
+  --enable-rbac-authorization true
+
+# Save the Key Vault resource ID for role assignments
+$KV_RESOURCE_ID = az keyvault show `
+  --name $KEYVAULT_NAME `
+  --query id `
+  --output tsv
+```
+
+### Path A only — Azure Container Registry
+
+Skip this block if you are using the upstream GHCR image (Path B).
+
+```powershell
+# admin-enabled false: use Managed Identity to pull images, not admin credentials
+az acr create `
+  --resource-group $RESOURCE_GROUP `
+  --name $ACR_NAME `
+  --sku Basic `
+  --admin-enabled false
+
+$ACR_LOGIN_SERVER = az acr show `
+  --name $ACR_NAME `
+  --query loginServer `
+  --output tsv
+
+$ACR_RESOURCE_ID = az acr show `
+  --name $ACR_NAME `
+  --query id `
+  --output tsv
+
+Write-Host "ACR login server: $ACR_LOGIN_SERVER"
+```
+
+---
+
+## Phase 3 — Log Analytics Workspace and Managed Identity
+
+### Log Analytics
+
+ACA streams all container stdout/stderr to Log Analytics automatically. The MCP server logs every tool call, OAuth event, and error — all of it appears here.
+
+```powershell
+az monitor log-analytics workspace create `
+  --resource-group $RESOURCE_GROUP `
+  --workspace-name $LAW_NAME `
+  --location $LOCATION
+
+$LAW_CUSTOMER_ID = az monitor log-analytics workspace show `
+  --resource-group $RESOURCE_GROUP `
+  --workspace-name $LAW_NAME `
+  --query customerId `
+  --output tsv
+
+$LAW_KEY = az monitor log-analytics workspace get-shared-keys `
+  --resource-group $RESOURCE_GROUP `
+  --workspace-name $LAW_NAME `
+  --query primarySharedKey `
+  --output tsv
+```
+
+### Managed Identity
+
+The Container App uses this identity to pull images from ACR (Path A) and read secrets from Key Vault.
+
+```powershell
+az identity create `
+  --name $IDENTITY_NAME `
+  --resource-group $RESOURCE_GROUP
+
+$IDENTITY_PRINCIPAL_ID = az identity show `
+  --name $IDENTITY_NAME `
+  --resource-group $RESOURCE_GROUP `
+  --query principalId `
+  --output tsv
+
+$IDENTITY_RESOURCE_ID = az identity show `
+  --name $IDENTITY_NAME `
+  --resource-group $RESOURCE_GROUP `
+  --query id `
+  --output tsv
+
+# --- Role: Key Vault Secrets User ---
+az role assignment create `
+  --assignee $IDENTITY_PRINCIPAL_ID `
+  --role "Key Vault Secrets User" `
+  --scope $KV_RESOURCE_ID
+
+# --- Role: AcrPull (Path A only) ---
+# Skip if using GHCR (Path B)
+az role assignment create `
+  --assignee $IDENTITY_PRINCIPAL_ID `
+  --role "AcrPull" `
+  --scope $ACR_RESOURCE_ID
+
+Write-Host "Identity principal ID: $IDENTITY_PRINCIPAL_ID"
+Write-Host "Identity resource ID:  $IDENTITY_RESOURCE_ID"
+```
+
+> Role assignments can take 1–2 minutes to propagate. If you hit permission errors in later phases, wait a moment and retry.
+
+---
+
+## Phase 4 — Container Apps Environment
+
+```powershell
+az extension add --name containerapp --upgrade
+
+az containerapp env create `
+  --name $ACA_ENV_NAME `
+  --resource-group $RESOURCE_GROUP `
+  --location $LOCATION `
+  --logs-workspace-id $LAW_CUSTOMER_ID `
+  --logs-workspace-key $LAW_KEY
+```
+
+---
+
+## Phase 5 — Store All Secrets in Key Vault
+
+Every configuration value lives in Key Vault. The Container App references all of these via `secretref:`.
+
+```powershell
+# --- ConnectWise Manage ---
+az keyvault secret set --vault-name $KEYVAULT_NAME --name "CW-COMPANY-ID"          --value $CW_COMPANY_ID
+az keyvault secret set --vault-name $KEYVAULT_NAME --name "CW-PUBLIC-KEY"           --value $CW_PUBLIC_KEY
+az keyvault secret set --vault-name $KEYVAULT_NAME --name "CW-PRIVATE-KEY"          --value $CW_PRIVATE_KEY
+az keyvault secret set --vault-name $KEYVAULT_NAME --name "CW-CLIENT-ID"            --value $CW_CLIENT_ID
+az keyvault secret set --vault-name $KEYVAULT_NAME --name "CW-URL"                  --value $CW_URL
+az keyvault secret set --vault-name $KEYVAULT_NAME --name "CW-REJECT-UNAUTHORIZED"  --value $CW_REJECT_UNAUTHORIZED
+
+# --- Entra ID / OAuth ---
+az keyvault secret set --vault-name $KEYVAULT_NAME --name "AZURE-TENANT-ID"         --value $AZURE_TENANT_ID
+az keyvault secret set --vault-name $KEYVAULT_NAME --name "AZURE-CLIENT-ID"         --value $AZURE_CLIENT_ID
+az keyvault secret set --vault-name $KEYVAULT_NAME --name "AZURE-AUDIENCE"          --value $AZURE_AUDIENCE
+az keyvault secret set --vault-name $KEYVAULT_NAME --name "AZURE-REQUIRED-ROLE"     --value "CWM.Access"
+
+# --- MCP Server ---
+az keyvault secret set --vault-name $KEYVAULT_NAME --name "MCP-TRANSPORT"           --value "http"
+az keyvault secret set --vault-name $KEYVAULT_NAME --name "MCP-HTTP-PORT"           --value "8080"
+az keyvault secret set --vault-name $KEYVAULT_NAME --name "MCP-HTTP-HOST"           --value "0.0.0.0"
+az keyvault secret set --vault-name $KEYVAULT_NAME --name "AUTH-MODE"               --value "env"
+az keyvault secret set --vault-name $KEYVAULT_NAME --name "MCP-OAUTH-ENABLED"       --value "true"
+
+# --- Optional: Static bearer token for Claude Code CLI ---
+# Skip (or set to a random string) if you do not need CLI access
+# Generate: openssl rand -hex 32
+az keyvault secret set --vault-name $KEYVAULT_NAME --name "MCP-BEARER-TOKEN"        --value $MCP_BEARER_TOKEN
+
+# --- Runtime ---
+az keyvault secret set --vault-name $KEYVAULT_NAME --name "NODE-ENV"                --value "production"
+az keyvault secret set --vault-name $KEYVAULT_NAME --name "LOG-LEVEL"               --value "info"
+
+# Note: MCP-SERVER-URL is set in Phase 8 after the ACA FQDN is known.
+```
+
+### Retrieve Secret URIs
+
+ACA Key Vault references require the versioned secret URI. Retrieve all of them now:
+
+```powershell
+$KV_URI_CW_COMPANY    = az keyvault secret show --vault-name $KEYVAULT_NAME --name "CW-COMPANY-ID"         --query id --output tsv
+$KV_URI_CW_PUBLIC     = az keyvault secret show --vault-name $KEYVAULT_NAME --name "CW-PUBLIC-KEY"          --query id --output tsv
+$KV_URI_CW_PRIVATE    = az keyvault secret show --vault-name $KEYVAULT_NAME --name "CW-PRIVATE-KEY"         --query id --output tsv
+$KV_URI_CW_CLIENT     = az keyvault secret show --vault-name $KEYVAULT_NAME --name "CW-CLIENT-ID"           --query id --output tsv
+$KV_URI_CW_URL        = az keyvault secret show --vault-name $KEYVAULT_NAME --name "CW-URL"                 --query id --output tsv
+$KV_URI_CW_REJECT     = az keyvault secret show --vault-name $KEYVAULT_NAME --name "CW-REJECT-UNAUTHORIZED" --query id --output tsv
+$KV_URI_TENANT_ID     = az keyvault secret show --vault-name $KEYVAULT_NAME --name "AZURE-TENANT-ID"        --query id --output tsv
+$KV_URI_CLIENT_ID     = az keyvault secret show --vault-name $KEYVAULT_NAME --name "AZURE-CLIENT-ID"        --query id --output tsv
+$KV_URI_AUDIENCE      = az keyvault secret show --vault-name $KEYVAULT_NAME --name "AZURE-AUDIENCE"         --query id --output tsv
+$KV_URI_REQUIRED_ROLE = az keyvault secret show --vault-name $KEYVAULT_NAME --name "AZURE-REQUIRED-ROLE"    --query id --output tsv
+$KV_URI_TRANSPORT     = az keyvault secret show --vault-name $KEYVAULT_NAME --name "MCP-TRANSPORT"          --query id --output tsv
+$KV_URI_HTTP_PORT     = az keyvault secret show --vault-name $KEYVAULT_NAME --name "MCP-HTTP-PORT"          --query id --output tsv
+$KV_URI_HTTP_HOST     = az keyvault secret show --vault-name $KEYVAULT_NAME --name "MCP-HTTP-HOST"          --query id --output tsv
+$KV_URI_AUTH_MODE     = az keyvault secret show --vault-name $KEYVAULT_NAME --name "AUTH-MODE"              --query id --output tsv
+$KV_URI_OAUTH         = az keyvault secret show --vault-name $KEYVAULT_NAME --name "MCP-OAUTH-ENABLED"      --query id --output tsv
+$KV_URI_BEARER        = az keyvault secret show --vault-name $KEYVAULT_NAME --name "MCP-BEARER-TOKEN"       --query id --output tsv
+$KV_URI_NODE_ENV      = az keyvault secret show --vault-name $KEYVAULT_NAME --name "NODE-ENV"               --query id --output tsv
+$KV_URI_LOG_LEVEL     = az keyvault secret show --vault-name $KEYVAULT_NAME --name "LOG-LEVEL"              --query id --output tsv
+```
+
+---
+
+## Phase 6 — Container Image
+
+### Path A — Build and Push to ACR (fork / custom build)
+
+Use this path if you are deploying a fork with custom changes.
+
+```powershell
+# Authenticate Docker to ACR using your Azure login (no admin password needed)
+az acr login --name $ACR_NAME
+
+# Build from the repo root
+docker build -t "$ACR_LOGIN_SERVER/connectwise-manage-mcp:latest" .
+
+# Push to ACR
+docker push "$ACR_LOGIN_SERVER/connectwise-manage-mcp:latest"
+
+# Verify the image is there
+az acr repository list --name $ACR_NAME --output table
+
+# Set the image reference variable used in Phase 7
+$IMAGE_REF = "$ACR_LOGIN_SERVER/connectwise-manage-mcp:latest"
+```
+
+### Path B — Use Upstream GHCR Image (no ACR required)
+
+Use this path if you are deploying the unmodified upstream image. No Docker build needed; skip the ACR steps in Phases 2 and 3 as well.
+
+```powershell
+# Set the image reference variable used in Phase 7
+$IMAGE_REF = "ghcr.io/wyre-technology/connectwise-manage-mcp:latest"
+```
+
+> **Note:** If your fork's changes are merged upstream, you can switch from Path A to Path B and decommission ACR entirely.
+
+---
+
+## Phase 7 — Deploy Container App (Step 1: without MCP_SERVER_URL)
+
+### Why two steps?
+
+`MCP_SERVER_URL` must be set to the Container App's public HTTPS URL — it appears in the OAuth discovery documents that Claude.ai reads. But ACA generates this URL only after the app is created.
+
+In this step we create the app with all secrets except `MCP_SERVER_URL`. The server starts and passes health checks, but OAuth will not work yet because the discovery endpoints return `http://localhost:8080` as the server URL. **Do not connect Claude.ai yet.**
+
+### Path A — With ACR
+
+```powershell
+az containerapp create `
+  --name $ACA_APP_NAME `
+  --resource-group $RESOURCE_GROUP `
+  --environment $ACA_ENV_NAME `
+  --image $IMAGE_REF `
+  --registry-server $ACR_LOGIN_SERVER `
+  --registry-identity $IDENTITY_RESOURCE_ID `
+  --user-assigned $IDENTITY_RESOURCE_ID `
+  --target-port 8080 `
+  --ingress external `
+  --min-replicas 1 `
+  --max-replicas 3 `
+  --cpu 0.5 `
+  --memory 1.0Gi `
+  --secrets `
+    "cw-company-id=keyvaultref:$KV_URI_CW_COMPANY,identityref:$IDENTITY_RESOURCE_ID" `
+    "cw-public-key=keyvaultref:$KV_URI_CW_PUBLIC,identityref:$IDENTITY_RESOURCE_ID" `
+    "cw-private-key=keyvaultref:$KV_URI_CW_PRIVATE,identityref:$IDENTITY_RESOURCE_ID" `
+    "cw-client-id=keyvaultref:$KV_URI_CW_CLIENT,identityref:$IDENTITY_RESOURCE_ID" `
+    "cw-url=keyvaultref:$KV_URI_CW_URL,identityref:$IDENTITY_RESOURCE_ID" `
+    "cw-reject-unauthorized=keyvaultref:$KV_URI_CW_REJECT,identityref:$IDENTITY_RESOURCE_ID" `
+    "azure-tenant-id=keyvaultref:$KV_URI_TENANT_ID,identityref:$IDENTITY_RESOURCE_ID" `
+    "azure-client-id=keyvaultref:$KV_URI_CLIENT_ID,identityref:$IDENTITY_RESOURCE_ID" `
+    "azure-audience=keyvaultref:$KV_URI_AUDIENCE,identityref:$IDENTITY_RESOURCE_ID" `
+    "azure-required-role=keyvaultref:$KV_URI_REQUIRED_ROLE,identityref:$IDENTITY_RESOURCE_ID" `
+    "mcp-transport=keyvaultref:$KV_URI_TRANSPORT,identityref:$IDENTITY_RESOURCE_ID" `
+    "mcp-http-port=keyvaultref:$KV_URI_HTTP_PORT,identityref:$IDENTITY_RESOURCE_ID" `
+    "mcp-http-host=keyvaultref:$KV_URI_HTTP_HOST,identityref:$IDENTITY_RESOURCE_ID" `
+    "auth-mode=keyvaultref:$KV_URI_AUTH_MODE,identityref:$IDENTITY_RESOURCE_ID" `
+    "mcp-oauth-enabled=keyvaultref:$KV_URI_OAUTH,identityref:$IDENTITY_RESOURCE_ID" `
+    "mcp-bearer-token=keyvaultref:$KV_URI_BEARER,identityref:$IDENTITY_RESOURCE_ID" `
+    "node-env=keyvaultref:$KV_URI_NODE_ENV,identityref:$IDENTITY_RESOURCE_ID" `
+    "log-level=keyvaultref:$KV_URI_LOG_LEVEL,identityref:$IDENTITY_RESOURCE_ID" `
+  --env-vars `
+    "CW_MANAGE_COMPANY_ID=secretref:cw-company-id" `
+    "CW_MANAGE_PUBLIC_KEY=secretref:cw-public-key" `
+    "CW_MANAGE_PRIVATE_KEY=secretref:cw-private-key" `
+    "CW_MANAGE_CLIENT_ID=secretref:cw-client-id" `
+    "CW_MANAGE_URL=secretref:cw-url" `
+    "CW_MANAGE_REJECT_UNAUTHORIZED=secretref:cw-reject-unauthorized" `
+    "AZURE_TENANT_ID=secretref:azure-tenant-id" `
+    "AZURE_CLIENT_ID=secretref:azure-client-id" `
+    "AZURE_AUDIENCE=secretref:azure-audience" `
+    "AZURE_REQUIRED_ROLE=secretref:azure-required-role" `
+    "MCP_TRANSPORT=secretref:mcp-transport" `
+    "MCP_HTTP_PORT=secretref:mcp-http-port" `
+    "MCP_HTTP_HOST=secretref:mcp-http-host" `
+    "AUTH_MODE=secretref:auth-mode" `
+    "MCP_OAUTH_ENABLED=secretref:mcp-oauth-enabled" `
+    "MCP_BEARER_TOKEN=secretref:mcp-bearer-token" `
+    "NODE_ENV=secretref:node-env" `
+    "LOG_LEVEL=secretref:log-level"
+```
+
+### Path B — Without ACR (GHCR public image)
+
+The command is identical except there is no `--registry-server`, `--registry-identity`, or `AcrPull` needed. ACA can pull public GHCR images without credentials.
+
+```powershell
+az containerapp create `
+  --name $ACA_APP_NAME `
+  --resource-group $RESOURCE_GROUP `
+  --environment $ACA_ENV_NAME `
+  --image $IMAGE_REF `
+  --user-assigned $IDENTITY_RESOURCE_ID `
+  --target-port 8080 `
+  --ingress external `
+  --min-replicas 1 `
+  --max-replicas 3 `
+  --cpu 0.5 `
+  --memory 1.0Gi `
+  --secrets `
+    "cw-company-id=keyvaultref:$KV_URI_CW_COMPANY,identityref:$IDENTITY_RESOURCE_ID" `
+    "cw-public-key=keyvaultref:$KV_URI_CW_PUBLIC,identityref:$IDENTITY_RESOURCE_ID" `
+    "cw-private-key=keyvaultref:$KV_URI_CW_PRIVATE,identityref:$IDENTITY_RESOURCE_ID" `
+    "cw-client-id=keyvaultref:$KV_URI_CW_CLIENT,identityref:$IDENTITY_RESOURCE_ID" `
+    "cw-url=keyvaultref:$KV_URI_CW_URL,identityref:$IDENTITY_RESOURCE_ID" `
+    "cw-reject-unauthorized=keyvaultref:$KV_URI_CW_REJECT,identityref:$IDENTITY_RESOURCE_ID" `
+    "azure-tenant-id=keyvaultref:$KV_URI_TENANT_ID,identityref:$IDENTITY_RESOURCE_ID" `
+    "azure-client-id=keyvaultref:$KV_URI_CLIENT_ID,identityref:$IDENTITY_RESOURCE_ID" `
+    "azure-audience=keyvaultref:$KV_URI_AUDIENCE,identityref:$IDENTITY_RESOURCE_ID" `
+    "azure-required-role=keyvaultref:$KV_URI_REQUIRED_ROLE,identityref:$IDENTITY_RESOURCE_ID" `
+    "mcp-transport=keyvaultref:$KV_URI_TRANSPORT,identityref:$IDENTITY_RESOURCE_ID" `
+    "mcp-http-port=keyvaultref:$KV_URI_HTTP_PORT,identityref:$IDENTITY_RESOURCE_ID" `
+    "mcp-http-host=keyvaultref:$KV_URI_HTTP_HOST,identityref:$IDENTITY_RESOURCE_ID" `
+    "auth-mode=keyvaultref:$KV_URI_AUTH_MODE,identityref:$IDENTITY_RESOURCE_ID" `
+    "mcp-oauth-enabled=keyvaultref:$KV_URI_OAUTH,identityref:$IDENTITY_RESOURCE_ID" `
+    "mcp-bearer-token=keyvaultref:$KV_URI_BEARER,identityref:$IDENTITY_RESOURCE_ID" `
+    "node-env=keyvaultref:$KV_URI_NODE_ENV,identityref:$IDENTITY_RESOURCE_ID" `
+    "log-level=keyvaultref:$KV_URI_LOG_LEVEL,identityref:$IDENTITY_RESOURCE_ID" `
+  --env-vars `
+    "CW_MANAGE_COMPANY_ID=secretref:cw-company-id" `
+    "CW_MANAGE_PUBLIC_KEY=secretref:cw-public-key" `
+    "CW_MANAGE_PRIVATE_KEY=secretref:cw-private-key" `
+    "CW_MANAGE_CLIENT_ID=secretref:cw-client-id" `
+    "CW_MANAGE_URL=secretref:cw-url" `
+    "CW_MANAGE_REJECT_UNAUTHORIZED=secretref:cw-reject-unauthorized" `
+    "AZURE_TENANT_ID=secretref:azure-tenant-id" `
+    "AZURE_CLIENT_ID=secretref:azure-client-id" `
+    "AZURE_AUDIENCE=secretref:azure-audience" `
+    "AZURE_REQUIRED_ROLE=secretref:azure-required-role" `
+    "MCP_TRANSPORT=secretref:mcp-transport" `
+    "MCP_HTTP_PORT=secretref:mcp-http-port" `
+    "MCP_HTTP_HOST=secretref:mcp-http-host" `
+    "AUTH_MODE=secretref:auth-mode" `
+    "MCP_OAUTH_ENABLED=secretref:mcp-oauth-enabled" `
+    "MCP_BEARER_TOKEN=secretref:mcp-bearer-token" `
+    "NODE_ENV=secretref:node-env" `
+    "LOG_LEVEL=secretref:log-level"
+```
+
+### Confirm it started
+
+```powershell
+# Get the public FQDN — save this, you'll need it throughout
+$MCP_FQDN = az containerapp show `
+  --name $ACA_APP_NAME `
+  --resource-group $RESOURCE_GROUP `
+  --query properties.configuration.ingress.fqdn `
+  --output tsv
+
+Write-Host "Container App URL: https://$MCP_FQDN"
+
+# Health check — should return {"status":"ok","transport":"http","authMode":"env","oauthEnabled":true,...}
+Invoke-RestMethod -Uri "https://$MCP_FQDN/health"
+```
+
+If the health check returns 200 with `"oauthEnabled": true`, the container is running and Key Vault access is working. Proceed to Phase 8.
+
+---
+
+## Phase 8 — Set MCP_SERVER_URL (Step 2: complete OAuth config)
+
+Now that we have the FQDN, store it in Key Vault and wire it into the Container App. This makes the OAuth discovery endpoints return the correct URLs.
+
+```powershell
+$MCP_SERVER_URL = "https://$MCP_FQDN"
+
+# Store in Key Vault
+az keyvault secret set `
+  --vault-name $KEYVAULT_NAME `
+  --name "MCP-SERVER-URL" `
+  --value $MCP_SERVER_URL
+
+$KV_URI_MCP_URL = az keyvault secret show `
+  --vault-name $KEYVAULT_NAME `
+  --name "MCP-SERVER-URL" `
+  --query id `
+  --output tsv
+
+# Add the secret reference to the Container App
+az containerapp secret set `
+  --name $ACA_APP_NAME `
+  --resource-group $RESOURCE_GROUP `
+  --secrets "mcp-server-url=keyvaultref:$KV_URI_MCP_URL,identityref:$IDENTITY_RESOURCE_ID"
+
+# Wire the env var to the new secret — this triggers a new revision automatically
+az containerapp update `
+  --name $ACA_APP_NAME `
+  --resource-group $RESOURCE_GROUP `
+  --set-env-vars "MCP_SERVER_URL=secretref:mcp-server-url"
+
+Write-Host "MCP Server URL: $MCP_SERVER_URL"
+Write-Host "MCP Endpoint:   $MCP_SERVER_URL/mcp"
+```
+
+### Verify the OAuth discovery documents
+
+```powershell
+# Protected resource — authorization_servers must equal ["https://{your-fqdn}"]
+$pr = Invoke-RestMethod -Uri "https://$MCP_FQDN/.well-known/oauth-protected-resource"
+Write-Host "authorization_servers: $($pr.authorization_servers)"
+
+# Authorization server metadata — issuer must equal "https://{your-fqdn}"
+$as = Invoke-RestMethod -Uri "https://$MCP_FQDN/.well-known/oauth-authorization-server"
+Write-Host "issuer:                 $($as.issuer)"
+Write-Host "authorization_endpoint: $($as.authorization_endpoint)"
+Write-Host "token_endpoint:         $($as.token_endpoint)"
+```
+
+If `issuer` still shows `http://localhost:8080`, the new revision hasn't finished deploying. Wait 30 seconds and retry.
+
+---
+
+## Phase 9 — Connect Claude.ai
+
+1. Go to **Claude.ai → Settings → Integrations → Add custom integration**
+2. Enter URL: `https://{your-fqdn}/mcp`
+3. Select **OAuth 2.0**
+4. Click **Connect** — a Microsoft login page should appear
+5. Sign in with your Entra ID account
+6. The integration should show as **Connected**
+
+**Test it:**
+
+```
+List all open tickets
+```
+
+or
+
+```
+Search for companies matching "Acme"
+```
+
+---
+
+## Optional: Claude Code CLI Access
+
+The server supports a static `MCP_BEARER_TOKEN` alongside OAuth, allowing Claude Code CLI users to connect without going through the OAuth browser flow.
+
+If you set `$MCP_BEARER_TOKEN` in the Variables section above, add the server to Claude Code CLI with:
+
+```bash
+claude mcp add --transport http cwm "https://$MCP_FQDN/mcp" \
+  --header "Authorization: Bearer YOUR_BEARER_TOKEN"
+```
+
+> The bearer token uses timing-safe comparison internally. Generate a strong token with `openssl rand -hex 32` and store it only in Key Vault — never in shell history or config files.
+
+---
+
+## Optional: Custom Domain
+
+```powershell
+# Add your custom hostname
+az containerapp hostname add `
+  --name $ACA_APP_NAME `
+  --resource-group $RESOURCE_GROUP `
+  --hostname "mcp.yourcompany.com"
+
+# The command outputs a verification token and CNAME target.
+# In your DNS provider, create:
+#   CNAME  mcp.yourcompany.com  →  {your-fqdn}.azurecontainerapps.io
+#   TXT    asuid.mcp            →  {verification-token from above}
+
+# Once DNS propagates, bind the managed certificate
+az containerapp hostname bind `
+  --name $ACA_APP_NAME `
+  --resource-group $RESOURCE_GROUP `
+  --hostname "mcp.yourcompany.com" `
+  --environment $ACA_ENV_NAME `
+  --validation-method CNAME
+```
+
+Then update `MCP-SERVER-URL` in Key Vault to your custom domain and trigger a new revision:
+
+```powershell
+az keyvault secret set `
+  --vault-name $KEYVAULT_NAME `
+  --name "MCP-SERVER-URL" `
+  --value "https://mcp.yourcompany.com"
+
+az containerapp update `
+  --name $ACA_APP_NAME `
+  --resource-group $RESOURCE_GROUP `
+  --image $IMAGE_REF
+```
+
+---
+
+## Maintenance
+
+### View Live Logs
+
+```powershell
+# Stream live from the Container App
+az containerapp logs show `
+  --name $ACA_APP_NAME `
+  --resource-group $RESOURCE_GROUP `
+  --follow
+
+# Or query Log Analytics for historical logs
+# In the Azure portal: Log Analytics → $LAW_NAME → Logs
+# Sample Kusto query:
+# ContainerAppConsoleLogs_CL
+# | where ContainerAppName_s == "connectwise-manage-mcp"
+# | project TimeGenerated, Log_s
+# | order by TimeGenerated desc
+# | take 100
+```
+
+### Update to a New Image Version (Path A)
+
+```powershell
+cd /path/to/connectwise-manage-mcp
+git pull
+
+az acr login --name $ACR_NAME
+docker build -t "$ACR_LOGIN_SERVER/connectwise-manage-mcp:latest" .
+docker push "$ACR_LOGIN_SERVER/connectwise-manage-mcp:latest"
+
+az containerapp update `
+  --name $ACA_APP_NAME `
+  --resource-group $RESOURCE_GROUP `
+  --image "$ACR_LOGIN_SERVER/connectwise-manage-mcp:latest"
+```
+
+### Update to a New Image Version (Path B)
+
+```powershell
+# Force ACA to pull the latest GHCR image by triggering a new revision
+az containerapp update `
+  --name $ACA_APP_NAME `
+  --resource-group $RESOURCE_GROUP `
+  --image "ghcr.io/wyre-technology/connectwise-manage-mcp:latest"
+```
+
+### Rotate ConnectWise API Keys
+
+```powershell
+az keyvault secret set `
+  --vault-name $KEYVAULT_NAME `
+  --name "CW-PUBLIC-KEY" `
+  --value "NEW_PUBLIC_KEY"
+
+az keyvault secret set `
+  --vault-name $KEYVAULT_NAME `
+  --name "CW-PRIVATE-KEY" `
+  --value "NEW_PRIVATE_KEY"
+
+# Force a restart to pick up the new secret versions
+az containerapp update `
+  --name $ACA_APP_NAME `
+  --resource-group $RESOURCE_GROUP `
+  --image $IMAGE_REF
+```
+
+### Rotate the Static Bearer Token
+
+```powershell
+$NEW_TOKEN = (openssl rand -hex 32)
+
+az keyvault secret set `
+  --vault-name $KEYVAULT_NAME `
+  --name "MCP-BEARER-TOKEN" `
+  --value $NEW_TOKEN
+
+az containerapp update `
+  --name $ACA_APP_NAME `
+  --resource-group $RESOURCE_GROUP `
+  --image $IMAGE_REF
+
+Write-Host "New bearer token: $NEW_TOKEN"
+# Update the token in Claude Code CLI:
+# claude mcp remove cwm
+# claude mcp add --transport http cwm "https://$MCP_FQDN/mcp" --header "Authorization: Bearer $NEW_TOKEN"
+```
+
+### Teardown
+
+```powershell
+# Remove all resources at once — Key Vault uses soft delete by default (90-day recovery)
+az group delete --name $RESOURCE_GROUP --yes --no-wait
+
+# Permanently delete the Key Vault immediately (optional)
+az keyvault purge --name $KEYVAULT_NAME --location $LOCATION
+```
+
+---
+
+## Troubleshooting
+
+### "Couldn't reach the MCP server" in Claude.ai
+
+Check that `MCP_SERVER_URL` is set correctly:
+
+```powershell
+$as = Invoke-RestMethod -Uri "https://$MCP_FQDN/.well-known/oauth-authorization-server"
+$as.issuer
+# Must equal "https://{your-fqdn}", not "http://localhost:8080"
+```
+
+If it shows `localhost`, `MCP-SERVER-URL` in Key Vault wasn't picked up. Check:
+
+1. The secret exists: `az keyvault secret show --vault-name $KEYVAULT_NAME --name "MCP-SERVER-URL"`
+2. The Container App has the env var: `az containerapp show --name $ACA_APP_NAME --resource-group $RESOURCE_GROUP --query "properties.template.containers[0].env"`
+3. Force a new revision: `az containerapp update --name $ACA_APP_NAME --resource-group $RESOURCE_GROUP --image $IMAGE_REF`
+
+### OAuth Opens but Shows AADSTS50011 (Redirect URI Mismatch)
+
+The URI `https://claude.ai/api/mcp/auth_callback` is not registered, or it is registered under the wrong platform (Web or SPA instead of Mobile and desktop applications).
+
+Go to: **Azure portal → App registrations → {your app} → Authentication → Mobile and desktop applications → Add URI**
+
+Add exactly: `https://claude.ai/api/mcp/auth_callback`
+
+### AADSTS65001 — User Has Not Consented / No Role Assigned
+
+The user has not been assigned the `CWM.Access` app role.
+
+Go to: **Azure portal → Enterprise applications → CWM-MCP-Server → Users and groups → Add user/group**
+
+Select the user or group, assign the **CWM Access** role, and click **Assign**. See [`entra-app-registration.md`](entra-app-registration.md) Step 8 for details.
+
+### OAuth Completes but Token Validation Fails (Audience Mismatch)
+
+Check server logs for the actual audience in the token:
+
+```powershell
+az containerapp logs show `
+  --name $ACA_APP_NAME `
+  --resource-group $RESOURCE_GROUP `
+  --follow
+# Look for: "[auth]" log lines containing "tokenAudience"
+```
+
+Update `AZURE-AUDIENCE` in Key Vault to match the `tokenAudience` value exactly, then restart:
+
+```powershell
+az keyvault secret set `
+  --vault-name $KEYVAULT_NAME `
+  --name "AZURE-AUDIENCE" `
+  --value "THE_ACTUAL_AUDIENCE_FROM_LOGS"
+
+az containerapp update `
+  --name $ACA_APP_NAME `
+  --resource-group $RESOURCE_GROUP `
+  --image $IMAGE_REF
+```
+
+### Container Fails to Start (Key Vault Access Denied)
+
+The Managed Identity doesn't have the `Key Vault Secrets User` role yet. Role assignments can take a few minutes to propagate.
+
+```powershell
+az role assignment list `
+  --assignee $IDENTITY_PRINCIPAL_ID `
+  --role "Key Vault Secrets User" `
+  --scope $KV_RESOURCE_ID `
+  --output table
+```
+
+If the assignment is missing, re-run the role assignment from Phase 3 and wait 2 minutes before redeploying.
+
+### `accessTokenAcceptedVersion` Resets
+
+Azure occasionally resets this during manifest edits. If token issuer validation starts failing after previously working, re-check the app manifest in the portal and ensure `"accessTokenAcceptedVersion": 2` is present (integer, not string).
+
+### ConnectWise API Returns 401
+
+Verify the credentials stored in Key Vault are correct:
+
+```powershell
+az keyvault secret show --vault-name $KEYVAULT_NAME --name "CW-PUBLIC-KEY"  --query value --output tsv
+az keyvault secret show --vault-name $KEYVAULT_NAME --name "CW-COMPANY-ID"  --query value --output tsv
+```
+
+Also confirm the API member exists and is active in CWM under **Members → API Members**, and that the Client ID matches what is registered at `developer.connectwise.com`.
+
+---
+
+## Cost Estimate
+
+| Resource | Tier | Approx. Monthly |
+|---|---|---|
+| Azure Container Apps | Consumption (1 replica, 0.5 vCPU / 1 GB) | ~$10–15 |
+| Azure Container Registry | Basic (Path A only) | ~$5 |
+| Azure Key Vault | Standard (< 10K ops/mo) | ~$0.03 |
+| Log Analytics | Pay-per-GB (low volume) | ~$2–5 |
+| **Total (Path A)** | | **~$17–25/month** |
+| **Total (Path B, no ACR)** | | **~$12–20/month** |
+
+---
+
+## Security Summary
+
+| Control | Implementation |
+|---|---|
+| No secrets in source control | All values in Key Vault |
+| No secrets in shell history | Variables set once, referenced via `$KV_URI_*` |
+| No admin credentials for ACR | Managed Identity with AcrPull role (Path A) |
+| Transport encryption | ACA enforces HTTPS, no Caddy needed |
+| Authentication | Short-lived Azure AD JWTs (OAuth 2.1 with PKCE) |
+| Role-based access control | `CWM.Access` app role enforced on every request |
+| No shared bearer tokens | OAuth-only for Claude.ai; optional static token for CLI only |
+| Timing-safe token comparison | Bearer token uses `crypto.timingSafeEqual` to prevent oracle attacks |
+| Non-root container user | `cwmanage` (UID 1001) |
+| Request body size limit | 64 KB enforced on OAuth endpoints |
+| Audit trail | Log Analytics captures all tool calls and auth events |
+
+---
+
+*ConnectWise Manage MCP v1.2.0 · March 2026*
+*Entra ID app registration: [`entra-app-registration.md`](entra-app-registration.md)*
+*Self-hosted / Docker deployment: [`README.md`](README.md)*

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,15 @@
+{$MCP_HOSTNAME} {
+    log {
+        output stdout
+        format json
+    }
+
+    reverse_proxy connectwise-manage-mcp:8080
+
+    header {
+        X-Content-Type-Options nosniff
+        X-Frame-Options DENY
+        Referrer-Policy strict-origin-when-cross-origin
+        -Server
+    }
+}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Let your AI assistant work directly with ConnectWise Manage.** Search tickets, log time, look up companies and contacts, manage projects — through natural conversation instead of clicking through the CWM interface.
 
-This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that gives Claude (or any MCP-compatible AI) 27 tools covering the daily operations ConnectWise Manage shops depend on. Works with both **cloud-hosted and self-hosted** CWM instances — just point it at your server.
+This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that gives Claude (or any MCP-compatible AI) 34 tools covering the daily operations ConnectWise Manage shops depend on. Works with both **cloud-hosted and self-hosted** CWM instances — just point it at your server.
 
 > **Part of the [MSP Claude Plugins](https://github.com/wyre-technology/msp-claude-plugins) ecosystem** — a growing suite of AI integrations for the MSP stack including [Autotask](https://github.com/wyre-technology/autotask-mcp), [Datto RMM](https://github.com/wyre-technology/datto-rmm-mcp), [IT Glue](https://github.com/wyre-technology/itglue-mcp), [HaloPSA](https://github.com/wyre-technology/halopsa-mcp), [NinjaOne](https://github.com/wyre-technology/ninjaone-mcp), [Huntress](https://github.com/wyre-technology/huntress-mcp), and more. Built by MSPs, for MSPs.
 
@@ -14,6 +14,8 @@ This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) serve
 [![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/wyre-technology/connectwise-manage-mcp/tree/main)
 
 [![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/wyre-technology/connectwise-manage-mcp)
+
+For deploying to **Azure Container Apps** with Entra ID OAuth 2.1, see [AZURE_ACA_DEPLOYMENT.md](AZURE_ACA_DEPLOYMENT.md).
 
 ## Configuration
 
@@ -59,6 +61,8 @@ If your self-hosted instance uses a self-signed certificate, also set `CW_MANAGE
 - `cw_get_ticket` — Get a ticket by ID
 - `cw_create_ticket` — Create a new service ticket
 - `cw_update_ticket` — Update a ticket (JSON Patch)
+- `cw_get_ticket_notes` — Get all notes on a ticket (including child ticket notes)
+- `cw_add_ticket_note` — Add a note to a ticket (discussion, internal, or resolution)
 
 ### Companies
 - `cw_search_companies` — Search companies
@@ -75,6 +79,10 @@ If your self-hosted instance uses a self-signed certificate, also set `CW_MANAGE
 - `cw_search_projects` — Search projects
 - `cw_get_project` — Get a project by ID
 - `cw_create_project` — Create a new project
+- `cw_search_project_tickets` — Search tickets under a project
+- `cw_get_project_ticket` — Get a specific project ticket by ID
+- `cw_get_project_ticket_notes` — Get all notes on a project ticket (including child ticket notes)
+- `cw_add_project_ticket_note` — Add a note to a project ticket (discussion, internal, or resolution)
 
 ### Time Entries
 - `cw_search_time_entries` — Search time entries

--- a/docker-compose.caddy.yml
+++ b/docker-compose.caddy.yml
@@ -1,0 +1,53 @@
+services:
+  caddy:
+    image: caddy:2-alpine
+    container_name: connectwise-manage-mcp-caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    environment:
+      - MCP_HOSTNAME=${MCP_HOSTNAME}
+    depends_on:
+      - connectwise-manage-mcp
+
+  connectwise-manage-mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: production
+    image: ghcr.io/wyre-technology/connectwise-manage-mcp:latest
+    container_name: connectwise-manage-mcp-server
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      - CW_MANAGE_COMPANY_ID=${CW_MANAGE_COMPANY_ID}
+      - CW_MANAGE_PUBLIC_KEY=${CW_MANAGE_PUBLIC_KEY}
+      - CW_MANAGE_PRIVATE_KEY=${CW_MANAGE_PRIVATE_KEY}
+      - CW_MANAGE_CLIENT_ID=${CW_MANAGE_CLIENT_ID}
+      - MCP_TRANSPORT=http
+      - AUTH_MODE=env
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+      - NODE_ENV=production
+      - MCP_OAUTH_ENABLED=${MCP_OAUTH_ENABLED:-false}
+      - MCP_SERVER_URL=${MCP_SERVER_URL}
+      - AZURE_TENANT_ID=${AZURE_TENANT_ID}
+      - AZURE_CLIENT_ID=${AZURE_CLIENT_ID}
+      - AZURE_AUDIENCE=${AZURE_AUDIENCE}
+      - AZURE_REQUIRED_ROLE=${AZURE_REQUIRED_ROLE:-CWM.Access}
+      - MCP_BEARER_TOKEN=${MCP_BEARER_TOKEN}
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+volumes:
+  caddy-data:
+  caddy-config:

--- a/entra-app-registration.md
+++ b/entra-app-registration.md
@@ -1,0 +1,149 @@
+# Azure AD App Registration Setup
+
+This guide walks through creating the Entra ID (Azure AD) app registration required for the ConnectWise Manage MCP server's OAuth 2.1 authentication.
+
+> **Before you start:** You need the Global Administrator or Application Administrator role in your Entra tenant to complete these steps.
+
+---
+
+## 1. Create the App Registration
+
+1. Sign in to the [Azure Portal](https://portal.azure.com) and navigate to **Azure Active Directory** → **App registrations** → **New registration**
+2. Fill in the form:
+   - **Name:** `CWM-MCP-Server` (or any name you prefer)
+   - **Supported account types:** `Accounts in this organizational directory only (Single tenant)`
+   - **Redirect URI:** Leave blank for now — we'll add it in the next step
+3. Click **Register**
+4. Copy and save the following values from the **Overview** page — you'll need them in your `.env`:
+   - **Application (client) ID** → `AZURE_CLIENT_ID`
+   - **Directory (tenant) ID** → `AZURE_TENANT_ID`
+
+---
+
+## 2. Add the Redirect URI
+
+> **Critical:** The redirect URI must be registered under **Mobile and desktop applications**, not Web or SPA. Web requires a client secret; SPA binds tokens to the browser origin. Both will break the OAuth flow.
+
+1. In the app registration, go to **Authentication** → **Add a platform** → **Mobile and desktop applications**
+2. Under **Custom redirect URIs**, enter:
+   ```
+   https://claude.ai/api/mcp/auth_callback
+   ```
+3. Click **Configure**
+
+---
+
+## 3. Enable Public Client Flows
+
+Still on the **Authentication** page:
+
+1. Scroll down to **Advanced settings**
+2. Set **Allow public client flows** → **Yes**
+3. Click **Save**
+
+---
+
+## 4. Update the Manifest
+
+This step forces Azure AD to issue v2 tokens. Without it, tokens are issued in v1 format and issuer validation will fail silently.
+
+1. Go to **Manifest** in the left sidebar
+2. Find the `signInAudience` field and add `accessTokenAcceptedVersion` immediately after it:
+   ```json
+   "signInAudience": "AzureADMyOrg",
+   "accessTokenAcceptedVersion": 2,
+   ```
+   > The value must be the number `2`, not the string `"2"`.
+3. Click **Save**
+
+---
+
+## 5. Expose an API
+
+This creates the `api://` audience that the server validates tokens against.
+
+1. Go to **Expose an API** in the left sidebar
+2. Next to **Application ID URI**, click **Add** → accept the default value `api://<your-client-id>` → **Save**
+3. Under **Scopes defined by this API**, click **Add a scope**:
+   - **Scope name:** `access_as_user`
+   - **Who can consent:** `Admins and users`
+   - **Admin consent display name:** `Access CWM MCP Server`
+   - **Admin consent description:** `Allows the user to call the ConnectWise Manage MCP tools`
+   - **State:** `Enabled`
+4. Click **Add scope**
+5. Copy the full scope URI (e.g. `api://<client-id>/access_as_user`) — you don't need this in `.env` but it's useful for reference
+6. Set `AZURE_AUDIENCE` in your `.env` to:
+   ```
+   AZURE_AUDIENCE=api://<your-client-id>
+   ```
+
+---
+
+## 6. Create an App Role
+
+App roles let you restrict access to specific users or groups in your tenant.
+
+1. Go to **App roles** in the left sidebar → **Create app role**
+2. Fill in the form:
+   - **Display name:** `CWM Access`
+   - **Allowed member types:** `Users/Groups`
+   - **Value:** `CWM.Access`
+   - **Description:** `Grants access to the ConnectWise Manage MCP tools`
+   - **Do you want to enable this app role?** → checked
+3. Click **Apply**
+
+---
+
+## 7. Grant API Permissions
+
+1. Go to **API permissions** in the left sidebar
+2. Confirm the following **Microsoft Graph** delegated permissions are listed (they are usually pre-added):
+   - `openid`
+   - `profile`
+   - `email`
+3. If any are missing, click **Add a permission** → **Microsoft Graph** → **Delegated permissions** → search and add them
+4. Click **Grant admin consent for \<your tenant\>** → **Yes**
+
+---
+
+## 8. Assign the App Role to Users or Groups
+
+The app role created in Step 6 must be explicitly assigned — it isn't granted automatically to all tenant users.
+
+1. Navigate to **Azure Active Directory** → **Enterprise applications** → search for `CWM-MCP-Server` → open it
+2. Go to **Users and groups** → **Add user/group**
+3. Select the users or security group that should have access
+4. Under **Select a role**, choose **CWM Access**
+5. Click **Assign**
+
+---
+
+## 9. Summary of Values for `.env`
+
+After completing the steps above, your `.env` should have:
+
+```env
+AZURE_TENANT_ID=<Directory (tenant) ID from Overview>
+AZURE_CLIENT_ID=<Application (client) ID from Overview>
+AZURE_AUDIENCE=api://<Application (client) ID>
+AZURE_REQUIRED_ROLE=CWM.Access
+```
+
+---
+
+## Troubleshooting
+
+**OAuth tab opens but Azure shows `AADSTS50011` (redirect URI mismatch)**
+The redirect URI `https://claude.ai/api/mcp/auth_callback` is not registered, or it's registered under the wrong platform (Web or SPA instead of Mobile and desktop applications). Delete it from the wrong platform and re-add it under Mobile and desktop applications.
+
+**Token validation fails — logs show audience mismatch**
+Check the `[auth]` log line for `tokenAudience`. Set `AZURE_AUDIENCE` in `.env` to exactly match that value.
+```bash
+docker compose logs connectwise-manage-mcp | grep "\[auth\]"
+```
+
+**`AADSTS65001` — user has not consented / no role assigned**
+The user hasn't been assigned the `CWM.Access` app role. Complete Step 8 above.
+
+**`accessTokenAcceptedVersion` was not saved**
+Go back to the Manifest and verify the field is present with value `2` (integer, not string). If Azure reset it during a save, re-add it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.3"
+        "@modelcontextprotocol/sdk": "^1.25.3",
+        "jose": "^6.2.2"
       },
       "bin": {
         "connectwise-manage-mcp": "dist/index.js"
@@ -4886,9 +4887,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/package.json
+++ b/package.json
@@ -41,16 +41,17 @@
   },
   "homepage": "https://github.com/wyre-technology/connectwise-manage-mcp#readme",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.25.3"
+    "@modelcontextprotocol/sdk": "^1.25.3",
+    "jose": "^6.2.2"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^11.0.0",
     "@types/node": "^20.11.0",
-    "eslint": "^8.56.0",
     "@typescript-eslint/eslint-plugin": "^6.19.0",
     "@typescript-eslint/parser": "^6.19.0",
+    "eslint": "^8.56.0",
     "semantic-release": "^25.0.0",
     "typescript": "^5.3.3",
     "vitest": "^1.2.0"

--- a/src/auth/middleware.test.ts
+++ b/src/auth/middleware.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createHash, timingSafeEqual } from "node:crypto";
+import { AuthError, type EntraConfig } from "./types.js";
+import { validateToken } from "./middleware.js";
+
+// ---------------------------------------------------------------------------
+// Mock jose so tests don't hit real Azure AD
+// ---------------------------------------------------------------------------
+
+vi.mock("jose", async () => {
+  const actual = await vi.importActual<typeof import("jose")>("jose");
+  return {
+    ...actual,
+    createRemoteJWKSet: vi.fn(() => vi.fn()),
+    jwtVerify: vi.fn(),
+  };
+});
+
+import { jwtVerify } from "jose";
+
+// ---------------------------------------------------------------------------
+// Shared test config
+// ---------------------------------------------------------------------------
+
+const config: EntraConfig = {
+  tenantId: "test-tenant-id",
+  clientId: "test-client-id",
+  audience: "api://test-client-id",
+  requiredRole: "CWM.Access",
+  serverUrl: "https://mcp.example.com",
+};
+
+const mockJwks = vi.fn() as ReturnType<typeof import("jose").createRemoteJWKSet>;
+
+// ---------------------------------------------------------------------------
+// validateToken
+// ---------------------------------------------------------------------------
+
+describe("validateToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns EntraIdentity for a valid token with correct role", async () => {
+    vi.mocked(jwtVerify).mockResolvedValueOnce({
+      payload: {
+        tid: "test-tenant-id",
+        roles: ["CWM.Access"],
+        upn: "user@example.com",
+        name: "Test User",
+        oid: "test-oid",
+        aud: "api://test-client-id",
+        iss: `https://login.microsoftonline.com/test-tenant-id/v2.0`,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        nbf: Math.floor(Date.now() / 1000),
+        sub: "test-sub",
+      },
+      protectedHeader: { alg: "RS256" },
+    });
+
+    const identity = await validateToken("valid-token", config, mockJwks);
+
+    expect(identity.upn).toBe("user@example.com");
+    expect(identity.name).toBe("Test User");
+    expect(identity.roles).toContain("CWM.Access");
+    expect(identity.oid).toBe("test-oid");
+  });
+
+  it("throws AuthError(401) when tenant id does not match", async () => {
+    vi.mocked(jwtVerify).mockResolvedValueOnce({
+      payload: {
+        tid: "wrong-tenant-id",
+        roles: ["CWM.Access"],
+        upn: "user@example.com",
+        oid: "test-oid",
+        aud: "api://test-client-id",
+        iss: `https://login.microsoftonline.com/test-tenant-id/v2.0`,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        nbf: Math.floor(Date.now() / 1000),
+        sub: "test-sub",
+      },
+      protectedHeader: { alg: "RS256" },
+    });
+
+    await expect(validateToken("valid-token", config, mockJwks)).rejects.toMatchObject({
+      statusCode: 401,
+      message: expect.stringContaining("tenant"),
+    });
+  });
+
+  it("throws AuthError(403) when required role is missing", async () => {
+    vi.mocked(jwtVerify).mockResolvedValueOnce({
+      payload: {
+        tid: "test-tenant-id",
+        roles: ["SomeOtherRole"],
+        upn: "user@example.com",
+        oid: "test-oid",
+        aud: "api://test-client-id",
+        iss: `https://login.microsoftonline.com/test-tenant-id/v2.0`,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        nbf: Math.floor(Date.now() / 1000),
+        sub: "test-sub",
+      },
+      protectedHeader: { alg: "RS256" },
+    });
+
+    const error = await validateToken("valid-token", config, mockJwks).catch((e) => e);
+    expect(error).toBeInstanceOf(AuthError);
+    expect((error as AuthError).statusCode).toBe(403);
+    expect(error.message).toContain("CWM.Access");
+  });
+
+  it("throws AuthError(401) when all audiences fail validation", async () => {
+    vi.mocked(jwtVerify).mockRejectedValue(new Error("JWTClaimValidationFailed"));
+
+    const error = await validateToken("bad-token", config, mockJwks).catch((e) => e);
+    expect(error).toBeInstanceOf(AuthError);
+    expect((error as AuthError).statusCode).toBe(401);
+  });
+
+  it("propagates AuthError immediately without retrying other audiences", async () => {
+    const authErr = new AuthError("Access denied: missing required role 'CWM.Access'", 403);
+    vi.mocked(jwtVerify).mockResolvedValueOnce({
+      payload: {
+        tid: "test-tenant-id",
+        roles: [],
+        oid: "oid",
+        aud: "api://test-client-id",
+        iss: `https://login.microsoftonline.com/test-tenant-id/v2.0`,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        nbf: Math.floor(Date.now() / 1000),
+        sub: "sub",
+      },
+      protectedHeader: { alg: "RS256" },
+    });
+
+    const error = await validateToken("bad-role-token", config, mockJwks).catch((e) => e);
+    expect(error).toBeInstanceOf(AuthError);
+    // jwtVerify should only be called once — AuthError is not retried
+    expect(vi.mocked(jwtVerify)).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Static bearer token comparison (timing-safe, SHA-256)
+// ---------------------------------------------------------------------------
+
+describe("static bearer token comparison", () => {
+  function compareTokens(incoming: string, stored: string): boolean {
+    return timingSafeEqual(
+      createHash("sha256").update(incoming).digest(),
+      createHash("sha256").update(stored).digest(),
+    );
+  }
+
+  it("returns true for matching tokens", () => {
+    expect(compareTokens("secret-token", "secret-token")).toBe(true);
+  });
+
+  it("returns false for wrong token", () => {
+    expect(compareTokens("wrong-token", "secret-token")).toBe(false);
+  });
+
+  it("returns false for same-length wrong token (no length oracle)", () => {
+    const stored = "abcdefghij";
+    const wrong = "xxxxxxxxxx"; // same length, different content
+    expect(compareTokens(wrong, stored)).toBe(false);
+  });
+
+  it("returns false for shorter token without throwing", () => {
+    // SHA-256 hashes are always 32 bytes regardless of input length,
+    // so timingSafeEqual never throws a length mismatch error
+    expect(compareTokens("short", "much-longer-secret-token")).toBe(false);
+  });
+
+  it("returns false for empty string vs stored token", () => {
+    expect(compareTokens("", "secret-token")).toBe(false);
+  });
+});

--- a/src/auth/middleware.ts
+++ b/src/auth/middleware.ts
@@ -1,0 +1,137 @@
+import { createRemoteJWKSet, jwtVerify, type JWTPayload, type RemoteJWKSetOptions } from "jose";
+import { AuthError, type EntraConfig, type EntraIdentity } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export function getEntraConfig(): EntraConfig {
+  const tenantId = process.env.AZURE_TENANT_ID;
+  const clientId = process.env.AZURE_CLIENT_ID;
+  const audience = process.env.AZURE_AUDIENCE;
+  const serverUrl = process.env.MCP_SERVER_URL;
+
+  if (!tenantId || !clientId || !audience || !serverUrl) {
+    throw new Error(
+      "Missing required Entra ID environment variables: AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_AUDIENCE, MCP_SERVER_URL",
+    );
+  }
+
+  return {
+    tenantId,
+    clientId,
+    audience,
+    requiredRole: process.env.AZURE_REQUIRED_ROLE ?? "CWM.Access",
+    serverUrl: serverUrl.replace(/\/$/, ""),
+    bearerToken: process.env.MCP_BEARER_TOKEN || undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// JWKS client (cached per-process by jose)
+// ---------------------------------------------------------------------------
+
+type JwksClient = ReturnType<typeof createRemoteJWKSet>;
+
+export function createJwksClient(config: EntraConfig): JwksClient {
+  const jwksUrl = new URL(
+    `https://login.microsoftonline.com/${config.tenantId}/discovery/v2.0/keys`,
+  );
+  const options: RemoteJWKSetOptions = {
+    cacheMaxAge: 60 * 60 * 1000, // 1 hour
+  };
+  return createRemoteJWKSet(jwksUrl, options);
+}
+
+// ---------------------------------------------------------------------------
+// Token validation
+// ---------------------------------------------------------------------------
+
+interface EntraJwtPayload extends JWTPayload {
+  upn?: string;
+  unique_name?: string;
+  preferred_username?: string;
+  name?: string;
+  roles?: string[];
+  tid?: string;
+  oid?: string;
+}
+
+export async function validateToken(
+  token: string,
+  config: EntraConfig,
+  jwks: JwksClient,
+): Promise<EntraIdentity> {
+  // Try multiple audiences — Azure AD may issue tokens with api://clientId or
+  // just clientId depending on app registration configuration.
+  const audiencesToTry = [
+    config.audience,
+    config.clientId,
+    `api://${config.clientId}`,
+  ].filter((a, i, arr) => arr.indexOf(a) === i); // deduplicate
+
+  let lastError: unknown;
+
+  for (const aud of audiencesToTry) {
+    try {
+      const { payload } = await jwtVerify<EntraJwtPayload>(token, jwks, {
+        issuer: `https://login.microsoftonline.com/${config.tenantId}/v2.0`,
+        audience: aud,
+      });
+
+      // Validate tenant
+      if (payload.tid && payload.tid !== config.tenantId) {
+        throw new AuthError("Token tenant does not match expected tenant", 401);
+      }
+
+      // Validate app role
+      const roles: string[] = payload.roles ?? [];
+      if (!roles.includes(config.requiredRole)) {
+        console.error(
+          `[auth] Role check failed — token has roles: [${roles.join(", ")}], required: ${config.requiredRole}`,
+        );
+        throw new AuthError(
+          `Access denied: missing required role '${config.requiredRole}'`,
+          403,
+        );
+      }
+
+      const upn =
+        payload.upn ??
+        payload.unique_name ??
+        payload.preferred_username ??
+        payload.sub ??
+        "unknown";
+
+      return {
+        upn,
+        name: payload.name,
+        roles,
+        oid: payload.oid ?? payload.sub ?? "",
+      };
+    } catch (err) {
+      if (err instanceof AuthError) throw err;
+      lastError = err;
+    }
+  }
+
+  // All audiences failed — log the token's actual aud claim for diagnostics
+  try {
+    const parts = token.split(".");
+    if (parts.length === 3) {
+      const decoded = JSON.parse(
+        Buffer.from(parts[1]!, "base64url").toString("utf8"),
+      ) as EntraJwtPayload;
+      console.error(
+        `[auth] JWT validation failed. tokenAudience=${JSON.stringify(decoded.aud)} triedAudiences=${JSON.stringify(audiencesToTry)}`,
+      );
+    }
+  } catch {
+    // ignore decode errors
+  }
+
+  throw new AuthError(
+    `Invalid token: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+    401,
+  );
+}

--- a/src/auth/routes.ts
+++ b/src/auth/routes.ts
@@ -1,0 +1,225 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { EntraConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  const json = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(json),
+  });
+  res.end(json);
+}
+
+const MAX_BODY_BYTES = 65_536; // 64 KB — sufficient for any OAuth request body
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+
+    req.on("data", (chunk: Buffer) => {
+      totalBytes += chunk.length;
+      if (totalBytes > MAX_BODY_BYTES) {
+        req.destroy();
+        reject(new Error("Request body too large"));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// RFC 9728 — OAuth Protected Resource Metadata
+// GET /.well-known/oauth-protected-resource
+// ---------------------------------------------------------------------------
+
+export function handleProtectedResource(
+  res: ServerResponse,
+  config: EntraConfig,
+): void {
+  sendJson(res, 200, {
+    resource: `${config.serverUrl}/mcp`,
+    authorization_servers: [config.serverUrl],
+    bearer_methods_supported: ["header"],
+    scopes_supported: [`api://${config.clientId}/access_as_user`],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// RFC 8414 — Authorization Server Metadata
+// GET /.well-known/oauth-authorization-server
+//
+// IMPORTANT: issuer must equal serverUrl (not Azure AD's issuer).
+// Claude.ai validates issuer === the URL prefix used to fetch this document.
+// ---------------------------------------------------------------------------
+
+export function handleAuthServerMetadata(
+  res: ServerResponse,
+  config: EntraConfig,
+): void {
+  sendJson(res, 200, {
+    issuer: config.serverUrl,
+    authorization_endpoint: `${config.serverUrl}/authorize`,
+    token_endpoint: `${config.serverUrl}/token`,
+    registration_endpoint: `${config.serverUrl}/register`,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    code_challenge_methods_supported: ["S256"],
+    token_endpoint_auth_methods_supported: ["none"],
+    scopes_supported: [
+      `api://${config.clientId}/access_as_user`,
+      "openid",
+      "profile",
+      "email",
+      "offline_access",
+    ],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic Client Registration (RFC 7591)
+// POST /register
+//
+// Azure AD doesn't support open DCR. We return the pre-registered client_id
+// so Claude.ai can proceed with the OAuth flow.
+// ---------------------------------------------------------------------------
+
+export async function handleRegister(
+  req: IncomingMessage,
+  res: ServerResponse,
+  config: EntraConfig,
+): Promise<void> {
+  // Read and discard request body (Claude.ai sends redirect_uris etc.)
+  await readBody(req);
+
+  sendJson(res, 201, {
+    client_id: config.clientId,
+    client_id_issued_at: Math.floor(Date.now() / 1000),
+    redirect_uris: ["https://claude.ai/api/mcp/auth_callback"],
+    grant_types: ["authorization_code", "refresh_token"],
+    token_endpoint_auth_method: "none",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Authorization proxy
+// GET /authorize
+//
+// Rewrites the request for Azure AD:
+//   - Replaces client_id with AZURE_CLIENT_ID
+//   - Replaces scope with the API scope
+//   - Passes PKCE params and redirect_uri through unchanged
+// ---------------------------------------------------------------------------
+
+export function handleAuthorize(
+  req: IncomingMessage,
+  res: ServerResponse,
+  config: EntraConfig,
+): void {
+  const incomingUrl = new URL(
+    req.url ?? "/",
+    `https://${req.headers.host ?? "localhost"}`,
+  );
+
+  const azureParams = new URLSearchParams();
+
+  // Pass through PKCE and flow params
+  for (const key of [
+    "response_type",
+    "redirect_uri",
+    "state",
+    "code_challenge",
+    "code_challenge_method",
+    "nonce",
+    "response_mode",
+    "login_hint",
+  ]) {
+    const val = incomingUrl.searchParams.get(key);
+    if (val !== null) azureParams.set(key, val);
+  }
+
+  // Override client_id and scope
+  azureParams.set("client_id", config.clientId);
+  azureParams.set(
+    "scope",
+    `api://${config.clientId}/access_as_user openid profile email offline_access`,
+  );
+
+  const azureAuthUrl =
+    `https://login.microsoftonline.com/${config.tenantId}/oauth2/v2.0/authorize?` +
+    azureParams.toString();
+
+  res.writeHead(302, { Location: azureAuthUrl });
+  res.end();
+}
+
+// ---------------------------------------------------------------------------
+// Token proxy
+// POST /token
+//
+// Proxies the token exchange to Azure AD, replacing client_id.
+// ---------------------------------------------------------------------------
+
+export async function handleToken(
+  req: IncomingMessage,
+  res: ServerResponse,
+  config: EntraConfig,
+): Promise<void> {
+  const body = await readBody(req);
+  const params = new URLSearchParams(body);
+
+  // Override client_id; drop resource (Azure AD v2 uses scope, not resource —
+  // sending both causes AADSTS9010010 when they don't match)
+  params.set("client_id", config.clientId);
+  params.delete("resource");
+
+  // If scope is present (e.g. sent by Claude.ai), replace it with our API scope
+  if (params.has("scope")) {
+    params.set(
+      "scope",
+      `api://${config.clientId}/access_as_user openid profile email offline_access`,
+    );
+  }
+
+  const azureTokenUrl = `https://login.microsoftonline.com/${config.tenantId}/oauth2/v2.0/token`;
+
+  try {
+    const azureRes = await fetch(azureTokenUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: params.toString(),
+    });
+
+    const azureBody = await azureRes.text();
+    if (azureRes.status !== 200) {
+      console.error(`[token] Azure rejected token exchange — status: ${azureRes.status}, body: ${azureBody}`);
+      let sanitized: { error: string; error_description?: string };
+      try {
+        const parsed = JSON.parse(azureBody) as { error?: string; error_description?: string };
+        sanitized = {
+          error: parsed.error ?? "invalid_request",
+          error_description: parsed.error_description,
+        };
+      } catch {
+        sanitized = { error: "invalid_request" };
+      }
+      res.writeHead(azureRes.status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(sanitized));
+      return;
+    }
+
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(azureBody);
+  } catch (err) {
+    console.error("[auth] Token proxy error:", err);
+    res.writeHead(502, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "token_proxy_error", error_description: "Failed to reach Azure AD" }));
+  }
+}

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -1,0 +1,25 @@
+export interface EntraConfig {
+  tenantId: string;
+  clientId: string;
+  audience: string; // api://<clientId>
+  requiredRole: string; // e.g. "CWM.Access"
+  serverUrl: string; // https://mcp.yourdomain.com (no trailing slash)
+  bearerToken?: string; // static token for Claude Code CLI fallback
+}
+
+export interface EntraIdentity {
+  upn: string;
+  name?: string;
+  roles: string[];
+  oid: string;
+}
+
+export class AuthError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: 401 | 403,
+  ) {
+    super(message);
+    this.name = "AuthError";
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,15 @@
  *   MCP_HTTP_PORT               - HTTP port (default: 8080)
  *   MCP_HTTP_HOST               - HTTP host (default: 0.0.0.0)
  *   AUTH_MODE                   - "env" (default) or "gateway" for header-based auth
+ *
+ * Entra ID OAuth 2.1 (optional — set MCP_OAUTH_ENABLED=true to activate):
+ *   MCP_OAUTH_ENABLED           - Enable Entra ID auth middleware (default: false)
+ *   MCP_SERVER_URL              - Full public URL of this server (e.g. https://mcp.yourdomain.com)
+ *   AZURE_TENANT_ID             - Entra tenant GUID
+ *   AZURE_CLIENT_ID             - App registration client ID
+ *   AZURE_AUDIENCE              - Token audience, typically api://<AZURE_CLIENT_ID>
+ *   AZURE_REQUIRED_ROLE         - App role claim required on every request (default: CWM.Access)
+ *   MCP_BEARER_TOKEN            - Static bearer token for Claude Code CLI / Claude Desktop
  */
 
 import {
@@ -28,11 +37,21 @@ import {
   ServerResponse,
   Server as HttpServer,
 } from "node:http";
+import { createHash, timingSafeEqual } from "node:crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { getConfig, CwManageClient } from "./api-client.js";
+import { getEntraConfig, createJwksClient, validateToken } from "./auth/middleware.js";
+import {
+  handleProtectedResource,
+  handleAuthServerMetadata,
+  handleRegister,
+  handleAuthorize,
+  handleToken,
+} from "./auth/routes.js";
+import { AuthError } from "./auth/types.js";
 import { registerTicketTools } from "./tools/tickets.js";
 import { registerCompanyTools } from "./tools/companies.js";
 import { registerContactTools } from "./tools/contacts.js";
@@ -130,11 +149,77 @@ async function startHttpTransport(): Promise<void> {
   const authMode = process.env.AUTH_MODE || "env";
   const isGatewayMode = authMode === "gateway";
 
+  // ---------------------------------------------------------------------------
+  // Entra ID auth setup (optional)
+  // ---------------------------------------------------------------------------
+  const oauthEnabled = process.env.MCP_OAUTH_ENABLED === "true";
+  let entraConfig: ReturnType<typeof getEntraConfig> | null = null;
+  let jwksClient: ReturnType<typeof createJwksClient> | null = null;
+
+  if (oauthEnabled) {
+    entraConfig = getEntraConfig();
+    jwksClient = createJwksClient(entraConfig);
+    console.error(
+      `[auth] Entra ID OAuth enabled — tenant: ${entraConfig.tenantId}, required role: ${entraConfig.requiredRole}`,
+    );
+    if (entraConfig.bearerToken) {
+      console.error("[auth] Static bearer token fallback enabled (CLI/Desktop)");
+    }
+  }
+
   httpServer = createServer((req: IncomingMessage, res: ServerResponse) => {
     const url = new URL(
       req.url || "/",
       `http://${req.headers.host || "localhost"}`,
     );
+
+    // ------------------------------------------------------------------
+    // OAuth discovery + proxy endpoints (always available when OAuth on)
+    // ------------------------------------------------------------------
+    if (oauthEnabled && entraConfig) {
+      if (
+        url.pathname === "/.well-known/oauth-protected-resource" &&
+        req.method === "GET"
+      ) {
+        handleProtectedResource(res, entraConfig);
+        return;
+      }
+
+      if (
+        url.pathname === "/.well-known/oauth-authorization-server" &&
+        req.method === "GET"
+      ) {
+        handleAuthServerMetadata(res, entraConfig);
+        return;
+      }
+
+      if (url.pathname === "/register" && req.method === "POST") {
+        handleRegister(req, res, entraConfig).catch((err) => {
+          console.error("[auth] /register error:", err);
+          if (!res.headersSent) {
+            res.writeHead(500, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: "internal_error" }));
+          }
+        });
+        return;
+      }
+
+      if (url.pathname === "/authorize" && req.method === "GET") {
+        handleAuthorize(req, res, entraConfig);
+        return;
+      }
+
+      if (url.pathname === "/token" && req.method === "POST") {
+        handleToken(req, res, entraConfig).catch((err) => {
+          console.error("[auth] /token error:", err);
+          if (!res.headersSent) {
+            res.writeHead(502, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: "token_proxy_error" }));
+          }
+        });
+        return;
+      }
+    }
 
     // Health endpoint
     if (url.pathname === "/health") {
@@ -144,6 +229,7 @@ async function startHttpTransport(): Promise<void> {
           status: "ok",
           transport: "http",
           authMode: isGatewayMode ? "gateway" : "env",
+          oauthEnabled,
           timestamp: new Date().toISOString(),
         }),
       );
@@ -164,74 +250,136 @@ async function startHttpTransport(): Promise<void> {
         return;
       }
 
-      // In gateway mode, extract credentials from headers
-      if (isGatewayMode) {
-        const headers = req.headers as Record<
-          string,
-          string | string[] | undefined
-        >;
-        const companyId = headers["x-cw-company-id"] as string | undefined;
-        const publicKey = headers["x-cw-public-key"] as string | undefined;
-        const privateKey = headers["x-cw-private-key"] as string | undefined;
-        const clientId = headers["x-cw-client-id"] as string | undefined;
-        const baseUrl = headers["x-cw-url"] as string | undefined;
+      // ------------------------------------------------------------------
+      // Entra ID auth check
+      // ------------------------------------------------------------------
+      const handleMcp = async () => {
+        if (oauthEnabled && entraConfig) {
+          const authHeader = req.headers.authorization;
 
-        if (!companyId || !publicKey || !privateKey || !clientId) {
-          res.writeHead(401, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: "Missing credentials",
-              message:
-                "Gateway mode requires X-CW-Company-Id, X-CW-Public-Key, X-CW-Private-Key, and X-CW-Client-Id headers",
-              required: [
-                "X-CW-Company-Id",
-                "X-CW-Public-Key",
-                "X-CW-Private-Key",
-                "X-CW-Client-Id",
-              ],
-            }),
-          );
-          return;
-        }
-
-        process.env.CW_MANAGE_COMPANY_ID = companyId;
-        process.env.CW_MANAGE_PUBLIC_KEY = publicKey;
-        process.env.CW_MANAGE_PRIVATE_KEY = privateKey;
-        process.env.CW_MANAGE_CLIENT_ID = clientId;
-        if (baseUrl) {
-          process.env.CW_MANAGE_URL = baseUrl;
-        }
-      }
-
-      const server = createMcpServer();
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: undefined,
-        enableJsonResponse: true,
-      });
-
-      res.on("close", () => {
-        transport.close();
-        server.close();
-      });
-
-      server
-        .connect(transport as unknown as Transport)
-        .then(() => {
-          transport.handleRequest(req, res);
-        })
-        .catch((err) => {
-          console.error("MCP transport error:", err);
-          if (!res.headersSent) {
-            res.writeHead(500, { "Content-Type": "application/json" });
+          if (!authHeader?.startsWith("Bearer ")) {
+            res.writeHead(401, {
+              "Content-Type": "application/json",
+              "WWW-Authenticate": `Bearer resource_metadata="${entraConfig.serverUrl}/.well-known/oauth-protected-resource"`,
+            });
             res.end(
               JSON.stringify({
-                jsonrpc: "2.0",
-                error: { code: -32603, message: "Internal error" },
-                id: null,
+                error: "unauthorized",
+                message: "Bearer token required",
               }),
             );
+            return;
           }
+
+          const token = authHeader.slice(7);
+
+          try {
+            let identity;
+            // Static bearer token check (Claude Code CLI / Claude Desktop)
+            // Use timing-safe comparison to prevent token length oracle attacks
+            const staticTokenMatch =
+              entraConfig.bearerToken !== undefined &&
+              timingSafeEqual(
+                createHash("sha256").update(token).digest(),
+                createHash("sha256").update(entraConfig.bearerToken).digest(),
+              );
+            if (staticTokenMatch) {
+              identity = {
+                upn: "cli-user",
+                roles: [entraConfig.requiredRole],
+                oid: "static",
+              };
+            } else {
+              identity = await validateToken(token, entraConfig, jwksClient!);
+            }
+            console.error(
+              `[audit] ${identity.upn} | ${new Date().toISOString()} | POST /mcp`,
+            );
+          } catch (err) {
+            if (err instanceof AuthError) {
+              res.writeHead(err.statusCode, { "Content-Type": "application/json" });
+              res.end(JSON.stringify({ error: "auth_failed", message: err.message }));
+            } else {
+              console.error("[auth] Unexpected validation error:", err);
+              res.writeHead(500, { "Content-Type": "application/json" });
+              res.end(JSON.stringify({ error: "internal_error" }));
+            }
+            return;
+          }
+        }
+
+        // ------------------------------------------------------------------
+        // Gateway mode: extract CW credentials from headers
+        // ------------------------------------------------------------------
+        if (isGatewayMode) {
+          const headers = req.headers as Record<
+            string,
+            string | string[] | undefined
+          >;
+          const companyId = headers["x-cw-company-id"] as string | undefined;
+          const publicKey = headers["x-cw-public-key"] as string | undefined;
+          const privateKey = headers["x-cw-private-key"] as string | undefined;
+          const clientId = headers["x-cw-client-id"] as string | undefined;
+          const baseUrl = headers["x-cw-url"] as string | undefined;
+
+          if (!companyId || !publicKey || !privateKey || !clientId) {
+            res.writeHead(401, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({
+                error: "Missing credentials",
+                message:
+                  "Gateway mode requires X-CW-Company-Id, X-CW-Public-Key, X-CW-Private-Key, and X-CW-Client-Id headers",
+                required: [
+                  "X-CW-Company-Id",
+                  "X-CW-Public-Key",
+                  "X-CW-Private-Key",
+                  "X-CW-Client-Id",
+                ],
+              }),
+            );
+            return;
+          }
+
+          process.env.CW_MANAGE_COMPANY_ID = companyId;
+          process.env.CW_MANAGE_PUBLIC_KEY = publicKey;
+          process.env.CW_MANAGE_PRIVATE_KEY = privateKey;
+          process.env.CW_MANAGE_CLIENT_ID = clientId;
+          if (baseUrl) {
+            process.env.CW_MANAGE_URL = baseUrl;
+          }
+        }
+
+        // ------------------------------------------------------------------
+        // MCP handler
+        // ------------------------------------------------------------------
+        const server = createMcpServer();
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: undefined,
+          enableJsonResponse: true,
         });
+
+        res.on("close", () => {
+          transport.close();
+          server.close();
+        });
+
+        await server.connect(transport as unknown as Transport);
+        transport.handleRequest(req, res);
+      };
+
+      handleMcp().catch((err) => {
+        console.error("MCP transport error:", err);
+        if (!res.headersSent) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              error: { code: -32603, message: "Internal error" },
+              id: null,
+            }),
+          );
+        }
+      });
 
       return;
     }

--- a/wrangler.json
+++ b/wrangler.json
@@ -2,5 +2,13 @@
   "name": "connectwise-manage-mcp",
   "main": "dist/worker.js",
   "compatibility_date": "2026-02-01",
-  "compatibility_flags": ["nodejs_compat"]
+  "compatibility_flags": ["nodejs_compat"],
+  "vars": {
+    "MCP_OAUTH_ENABLED": "false",
+    "AZURE_TENANT_ID": "",
+    "AZURE_CLIENT_ID": "",
+    "AZURE_AUDIENCE": "",
+    "AZURE_REQUIRED_ROLE": "CWM.Access",
+    "MCP_SERVER_URL": ""
+  }
 }


### PR DESCRIPTION
## Summary

- Adds Entra ID OAuth 2.1 authentication middleware with Azure AD JWKS validation
- Implements OAuth discovery endpoints per RFC 8414 / RFC 9728
- Implements dynamic client registration per RFC 7591
- Adds authorization and token proxy endpoints for Azure AD
- Static bearer token fallback for Claude Code CLI / Claude Desktop (opt-in via MCP_BEARER_TOKEN)
- Adds Docker + Caddy deployment configuration
- Adds Azure Container Apps deployment guide and Entra app registration docs
- Security: timing-safe bearer token comparison (SHA-256 hashed before timingSafeEqual)
- Security: Azure AD error responses sanitized before being returned to clients
- Tests: 10 tests covering JWT validation, role checking, and token comparison

OAuth is entirely opt-in — existing deployments are unaffected unless MCP_OAUTH_ENABLED=true is set.

## Test plan

- [ ] Server starts without OAuth env vars and behaves identically to before
- [ ] With MCP_OAUTH_ENABLED=true, /.well-known/oauth-authorization-server returns correct metadata
- [ ] Valid Azure AD JWT with CWM.Access role grants access to /mcp
- [ ] JWT with wrong role returns 403; missing token returns 401
- [ ] Static MCP_BEARER_TOKEN allows CLI/Desktop access without JWT
- [ ] POST /token with bad code returns sanitized error (no raw AADSTS details)
- [ ] npm test passes all 10 tests

