### PR TITLE
feat: add finance agreements and sales opportunities tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,8 @@ import { registerConfigurationTools } from "./tools/configurations.js";
 import { registerServiceTools } from "./tools/service.js";
 import { registerActivityTools } from "./tools/activities.js";
 import { registerHealthTools } from "./tools/health.js";
+import { registerAgreementTools } from "./tools/agreements.js";
+import { registerOpportunityTools } from "./tools/opportunities.js";
 
 // ---------------------------------------------------------------------------
 // Server factory
@@ -122,6 +124,8 @@ function createMcpServer(): McpServer {
   registerServiceTools(server, client);
   registerActivityTools(server, client);
   registerHealthTools(server, client);
+  registerAgreementTools(server, client);
+  registerOpportunityTools(server, client);
 
   return server;
 }

--- a/src/tools/agreements.ts
+++ b/src/tools/agreements.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CwManageClient } from "../api-client.js";
+
+export function registerAgreementTools(server: McpServer, client: CwManageClient) {
+  server.tool(
+    "cw_search_agreements",
+    "Search finance agreements (recurring revenue contracts) in ConnectWise Manage. Use 'conditions' for CW query syntax (e.g. \"cancelledFlag = false\", \"company/name = 'Acme'\").",
+    {
+      conditions: z.string().optional().describe("ConnectWise conditions query string"),
+      page: z.number().optional().describe("Page number (default: 1)"),
+      pageSize: z.number().optional().describe("Results per page (default: 25, max: 1000)"),
+      orderBy: z.string().optional().describe("Field to order by"),
+    },
+    async ({ conditions, page, pageSize, orderBy }) => {
+      const result = await client.get("/finance/agreements", {
+        conditions,
+        page: page ?? 1,
+        pageSize: pageSize ?? 25,
+        orderBy,
+      });
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "cw_get_agreement",
+    "Get a specific finance agreement by ID.",
+    {
+      id: z.number().describe("Agreement ID"),
+    },
+    async ({ id }) => {
+      const result = await client.get(`/finance/agreements/${id}`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "cw_get_agreement_additions",
+    "Get additions (line items) for a specific agreement.",
+    {
+      agreementId: z.number().describe("Agreement ID"),
+      page: z.number().optional().describe("Page number (default: 1)"),
+      pageSize: z.number().optional().describe("Results per page (default: 25, max: 1000)"),
+    },
+    async ({ agreementId, page, pageSize }) => {
+      const result = await client.get(`/finance/agreements/${agreementId}/additions`, {
+        page: page ?? 1,
+        pageSize: pageSize ?? 25,
+      });
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "cw_search_invoices",
+    "Search invoices in ConnectWise Manage.",
+    {
+      conditions: z.string().optional().describe("ConnectWise conditions query string (e.g. \"company/name = 'Acme'\")"),
+      page: z.number().optional().describe("Page number (default: 1)"),
+      pageSize: z.number().optional().describe("Results per page (default: 25, max: 1000)"),
+      orderBy: z.string().optional().describe("Field to order by (e.g. 'id desc')"),
+    },
+    async ({ conditions, page, pageSize, orderBy }) => {
+      const result = await client.get("/finance/invoices", {
+        conditions,
+        page: page ?? 1,
+        pageSize: pageSize ?? 25,
+        orderBy,
+      });
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "cw_get_invoice",
+    "Get a specific invoice by ID.",
+    {
+      id: z.number().describe("Invoice ID"),
+    },
+    async ({ id }) => {
+      const result = await client.get(`/finance/invoices/${id}`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/src/tools/opportunities.ts
+++ b/src/tools/opportunities.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CwManageClient } from "../api-client.js";
+
+export function registerOpportunityTools(server: McpServer, client: CwManageClient) {
+  server.tool(
+    "cw_search_opportunities",
+    "Search sales opportunities in ConnectWise Manage. Use 'conditions' for CW query syntax (e.g. \"status/name = '1. Open'\", \"closedFlag = false\").",
+    {
+      conditions: z.string().optional().describe("ConnectWise conditions query string"),
+      page: z.number().optional().describe("Page number (default: 1)"),
+      pageSize: z.number().optional().describe("Results per page (default: 25, max: 1000)"),
+      orderBy: z.string().optional().describe("Field to order by (e.g. 'id desc')"),
+    },
+    async ({ conditions, page, pageSize, orderBy }) => {
+      const result = await client.get("/sales/opportunities", {
+        conditions,
+        page: page ?? 1,
+        pageSize: pageSize ?? 25,
+        orderBy,
+      });
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "cw_get_opportunity",
+    "Get a specific sales opportunity by ID.",
+    {
+      id: z.number().describe("Opportunity ID"),
+    },
+    async ({ id }) => {
+      const result = await client.get(`/sales/opportunities/${id}`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "cw_search_opportunity_forecasts",
+    "Search opportunity forecasts/revenue items for a specific opportunity.",
+    {
+      opportunityId: z.number().describe("Opportunity ID"),
+      page: z.number().optional().describe("Page number (default: 1)"),
+      pageSize: z.number().optional().describe("Results per page (default: 25, max: 1000)"),
+    },
+    async ({ opportunityId, page, pageSize }) => {
+      const result = await client.get(`/sales/opportunities/${opportunityId}/forecast`, {
+        page: page ?? 1,
+        pageSize: pageSize ?? 25,
+      });
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "cw_search_opportunity_notes",
+    "Get notes on a specific sales opportunity.",
+    {
+      opportunityId: z.number().describe("Opportunity ID"),
+      page: z.number().optional().describe("Page number (default: 1)"),
+      pageSize: z.number().optional().describe("Results per page (default: 25, max: 1000)"),
+    },
+    async ({ opportunityId, page, pageSize }) => {
+      const result = await client.get(`/sales/opportunities/${opportunityId}/notes`, {
+        page: page ?? 1,
+        pageSize: pageSize ?? 25,
+      });
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "cw_search_sales_stages",
+    "List sales pipeline stages in ConnectWise Manage.",
+    {
+      conditions: z.string().optional().describe("ConnectWise conditions query string"),
+      page: z.number().optional().describe("Page number (default: 1)"),
+      pageSize: z.number().optional().describe("Results per page (default: 25, max: 1000)"),
+    },
+    async ({ conditions, page, pageSize }) => {
+      const result = await client.get("/sales/stages", {
+        conditions,
+        page: page ?? 1,
+        pageSize: pageSize ?? 25,
+      });
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Adds 10 new read-only tools for the finance and sales modules that were missing from the current tool set:

### Agreements (5 tools)
- `cw_search_agreements` — Search/filter recurring revenue contracts with CW conditions
- `cw_get_agreement` — Get a specific agreement by ID
- `cw_get_agreement_additions` — Get line items/additions on an agreement
- `cw_search_invoices` — Search invoices
- `cw_get_invoice` — Get a specific invoice by ID

### Sales Opportunities (5 tools)
- `cw_search_opportunities` — Search/filter sales pipeline
- `cw_get_opportunity` — Get a specific opportunity by ID
- `cw_search_opportunity_forecasts` — Revenue forecast items for an opportunity
- `cw_search_opportunity_notes` — Notes on an opportunity
- `cw_search_sales_stages` — List pipeline stages

## Motivation

We needed to pull agreement billing data (MRR, contract terms, expiration dates) and sales pipeline data for an operational audit. These endpoints (`/finance/agreements`, `/finance/invoices`, `/sales/opportunities`, `/sales/stages`) were not covered by the existing tools, requiring direct API calls.

All new tools follow the same patterns as existing tools — read-only GET operations with conditions, pagination, and ordering support.

## Test plan

- [x] Verified `cw_search_agreements` returns full agreement details including billing amounts, cycles, and SLA terms
- [x] Verified `cw_search_opportunities` returns opportunities with custom fields, stages, and status
- [x] Verified pagination works on both tool sets
- [x] TypeScript compiles cleanly with `tsc`
- [x] No changes to existing tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)