### PR TITLE
fix(ci): gate docker/deploy on actual release to stop :latest tag regression

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,11 @@ jobs:
     name: Docker
     runs-on: ubuntu-latest
     needs: [release]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Gate on an actual semantic-release. A non-release push to main would
+    # otherwise rebuild and re-push :latest tagged with the stale package.json
+    # version, clobbering the correctly-tagged :latest from the last real
+    # release. Skipping docker cascades to deploy/registry (skipped dependency).
+    if: needs.release.outputs.released == 'true'
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
@@ -129,6 +131,7 @@ jobs:
           fi
           echo "version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
       - name: Build and push
+        id: push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
         with:
           context: .
@@ -179,28 +182,15 @@ jobs:
 
   deploy:
     name: Deploy to Azure Container Apps
-    runs-on: ubuntu-latest
-    needs: [docker]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    environment: production
+    needs: [release, docker]
+    if: needs.release.outputs.released == 'true'
     permissions:
       id-token: write
       contents: read
-    steps:
-      - name: Azure login (OIDC)
-        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5  # v2.3.0
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Deploy to Azure Container Apps
-        run: |
-          SHORT_SHA="${GITHUB_SHA::7}"
-          IMAGE="ghcr.io/${{ github.repository }}:latest"
-          echo "Deploying $IMAGE to mcpgw-prod-connectwise-manage (revision tag sha-${SHORT_SHA}-${GITHUB_RUN_ID})"
-          az containerapp update \
-            --name mcpgw-prod-connectwise-manage \
-            --resource-group mcp-gateway-prod \
-            --image "$IMAGE" \
-            --set-env-vars "IMAGE_VERSION=sha-${SHORT_SHA}-${GITHUB_RUN_ID}"
+    uses: wyre-technology/.github/.github/workflows/mcp-server-deploy.yml@d6ace529b210900f460cb365529f2a552daedf7a
+    with:
+      vendor-slug: connectwise-manage
+      image-name: ghcr.io/wyre-technology/connectwise-manage-mcp
+      digest: ${{ needs.docker.outputs.digest }}
+      version: ${{ needs.release.outputs.version }}
+    secrets: inherit


### PR DESCRIPTION
## Bug: vendor image drift / `:latest` tag regression

On **every** push to `main` — not just releases — the `docker` job rebuilt and
re-pushed the `ghcr.io/.../:latest` image. Because there is no
`@semantic-release/git` plugin, `package.json` is never committed back, so a
non-release push still carries the **stale** version. The rebuilt `:latest`
therefore clobbered the correctly-versioned `:latest` published by the last
real release, and the `deploy` job then shipped that stale image to production.

## Fix (one line)

Gate the `docker` job on an actual semantic-release:

```yaml
# before
if: github.event_name == 'push' && github.ref == 'refs/heads/main'
# after
if: needs.release.outputs.released == 'true'
```

`needs: [release]` was already present, so this is purely the `if:` condition.
When no release is published, `docker` is skipped, which cascades to `deploy`
and `mcp-registry` as skipped dependencies — no stale `:latest` is ever pushed.

## Effect of merging

Merging this triggers a corrective semantic-release, which republishes the
correct `:latest` (and `:vX.Y.Z`) and deploys the right image to production,
healing the drift.
