### PR TITLE
chore(release): publish to GitHub Packages; clarify deploy-button auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist/
 .env
 .DS_Store
 coverage/
+
+# Cloudflare Wrangler
+.wrangler/

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,7 +9,7 @@
     [
       "@semantic-release/npm",
       {
-        "npmPublish": false
+        "npmPublish": true
       }
     ],
     "@semantic-release/github"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [Unreleased]
+
+### Changed
+
+- Publish the package to the GitHub Packages npm registry (`npm.pkg.github.com`) on release: `@semantic-release/npm` `npmPublish` enabled and `publishConfig.registry` set.
+
+### Documentation
+
+- Clarify the "Deploy to Cloudflare Workers" / "Deploy to DigitalOcean" one-click flow: this server depends only on public npm packages, so the cloud builders install without any registry token. Installing the published package from GitHub Packages does require a GitHub PAT with `read:packages` (`export NODE_AUTH_TOKEN=$(gh auth token)`).
+
 # [1.4.0](https://github.com/wyre-technology/connectwise-manage-mcp/compare/v1.3.0...v1.4.0) (2026-04-03)
 
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) serve
 
 [![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/wyre-technology/connectwise-manage-mcp)
 
+> **Note on registry auth:** This server depends only on public npm packages, so the Cloudflare and DigitalOcean cloud builders install its dependencies anonymously — no token is required for one-click deploy. (If a future release adds a private `@wyre-technology/*` dependency, you would supply a GitHub PAT with `read:packages` as a build variable — `NODE_AUTH_TOKEN` for Cloudflare Workers, a build-time `GITHUB_TOKEN` secret for DigitalOcean.)
+>
+> **Installing the published package:** The released package is published to the [GitHub Packages](https://github.com/wyre-technology/connectwise-manage-mcp/pkgs/npm/connectwise-manage-mcp) npm registry, which requires authentication on every install (even for public packages). To install it, authenticate npm to `npm.pkg.github.com` with a GitHub PAT that has `read:packages`:
+>
+> ```bash
+> export NODE_AUTH_TOKEN=$(gh auth token)
+> npm install @wyre-technology/connectwise-manage-mcp
+> ```
+
 For deploying to **Azure Container Apps** with Entra ID OAuth 2.1, see [AZURE_ACA_DEPLOYMENT.md](AZURE_ACA_DEPLOYMENT.md).
 
 ## Configuration

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@wyre-technology/connectwise-manage-mcp",
   "version": "1.4.0",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "description": "ConnectWise Manage (PSA) MCP server for Claude",
   "type": "module",
   "main": "dist/index.js",

--- a/src/__tests__/worker.test.ts
+++ b/src/__tests__/worker.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for the Cloudflare Workers entrypoint.
+ *
+ * Drives the exported `fetch` handler directly with Web Standard Request objects
+ * (available natively in Node 18+), exercising the same WebStandardStreamableHTTP
+ * transport the Worker uses in production.
+ */
+
+import { describe, it, expect } from "vitest";
+import worker, { type Env } from "../worker.js";
+
+const MCP_HEADERS = {
+  Accept: "application/json, text/event-stream",
+  "Content-Type": "application/json",
+};
+
+async function mcp(body: unknown, env: Env = {}): Promise<Response> {
+  return worker.fetch(
+    new Request("http://worker.local/mcp", {
+      method: "POST",
+      headers: MCP_HEADERS,
+      body: JSON.stringify(body),
+    }),
+    env,
+  );
+}
+
+const GATEWAY_HEADERS = {
+  ...MCP_HEADERS,
+  "X-CW-Company-Id": "acme",
+  "X-CW-Public-Key": "pub",
+  "X-CW-Private-Key": "priv",
+  "X-CW-Client-Id": "client-guid",
+};
+
+describe("Cloudflare Worker entrypoint", () => {
+  it("serves a shallow health probe", async () => {
+    const res = await worker.fetch(new Request("http://worker.local/health"), {});
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "ok" });
+  });
+
+  it("answers CORS preflight", async () => {
+    const res = await worker.fetch(
+      new Request("http://worker.local/mcp", { method: "OPTIONS" }),
+      {},
+    );
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+
+  it("404s unknown paths", async () => {
+    const res = await worker.fetch(new Request("http://worker.local/nope"), {});
+    expect(res.status).toBe(404);
+  });
+
+  it("handles MCP initialize", async () => {
+    const res = await mcp({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "vitest", version: "0" },
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result?: { serverInfo?: { name?: string } };
+    };
+    expect(body.result?.serverInfo?.name).toBe("connectwise-manage-mcp");
+  });
+
+  it("lists the diagnostic tool when no credentials are configured", async () => {
+    const res = await mcp({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+      params: {},
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result?: { tools?: { name: string }[] };
+    };
+    const names = (body.result?.tools ?? []).map((t) => t.name);
+    expect(names).toContain("cw_test_connection");
+  });
+
+  it("lists the full tool set when credentials are supplied via gateway headers", async () => {
+    const res = await worker.fetch(
+      new Request("http://worker.local/mcp", {
+        method: "POST",
+        headers: GATEWAY_HEADERS,
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 3,
+          method: "tools/list",
+          params: {},
+        }),
+      }),
+      { AUTH_MODE: "gateway" },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result?: { tools?: { name: string }[] };
+    };
+    const names = (body.result?.tools ?? []).map((t) => t.name);
+    expect(names).toContain("cw_search_tickets");
+    expect(names).toContain("cw_get_ticket");
+    expect(names.length).toBeGreaterThan(10);
+  });
+
+  it("returns a graceful error for a credential-requiring tool when unconfigured", async () => {
+    const res = await mcp({
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: { name: "cw_test_connection", arguments: {} },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result?: { isError?: boolean; content?: { text?: string }[] };
+    };
+    expect(body.result?.isError).toBe(true);
+    expect(body.result?.content?.[0]?.text).toMatch(/credentials/i);
+  });
+
+  it("rejects /mcp in gateway mode without credential headers", async () => {
+    const res = await mcp(
+      {
+        jsonrpc: "2.0",
+        id: 5,
+        method: "tools/call",
+        params: { name: "cw_search_tickets", arguments: {} },
+      },
+      { AUTH_MODE: "gateway" },
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,11 +38,9 @@ import {
   Server as HttpServer,
 } from "node:http";
 import { createHash, timingSafeEqual } from "node:crypto";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import { getConfig, CwManageClient } from "./api-client.js";
 import { getEntraConfig, createJwksClient, validateToken } from "./auth/middleware.js";
 import {
   handleProtectedResource,
@@ -52,85 +50,11 @@ import {
   handleToken,
 } from "./auth/routes.js";
 import { AuthError } from "./auth/types.js";
-import { registerTicketTools } from "./tools/tickets.js";
-import { registerCompanyTools } from "./tools/companies.js";
-import { registerContactTools } from "./tools/contacts.js";
-import { registerProjectTools } from "./tools/projects.js";
-import { registerTimeEntryTools } from "./tools/time-entries.js";
-import { registerMemberTools } from "./tools/members.js";
-import { registerConfigurationTools } from "./tools/configurations.js";
-import { registerServiceTools } from "./tools/service.js";
-import { registerActivityTools } from "./tools/activities.js";
-import { registerCatalogTools } from "./tools/catalog.js";
-import { registerHealthTools } from "./tools/health.js";
-import { registerAgreementTools } from "./tools/agreements.js";
-import { registerOpportunityTools } from "./tools/opportunities.js";
-
-// ---------------------------------------------------------------------------
-// Server factory
-// ---------------------------------------------------------------------------
-
-function createMcpServer(): McpServer {
-  const server = new McpServer({
-    name: "connectwise-manage-mcp",
-    version: "1.1.5",
-  });
-
-  const config = getConfig();
-
-  if (!config) {
-    // Register a single diagnostic tool so the client gets a clear error
-    server.tool(
-      "cw_test_connection",
-      "Test the connection to ConnectWise Manage.",
-      {},
-      async () => ({
-        content: [
-          {
-            type: "text",
-            text: [
-              "Error: Missing ConnectWise Manage credentials.",
-              "",
-              "Required environment variables:",
-              "  CW_MANAGE_COMPANY_ID        - Your ConnectWise company identifier",
-              "  CW_MANAGE_PUBLIC_KEY        - API member public key",
-              "  CW_MANAGE_PRIVATE_KEY       - API member private key",
-              "  CW_MANAGE_CLIENT_ID         - Client ID from ConnectWise Developer Portal",
-              "",
-              "Optional:",
-              "  CW_MANAGE_URL               - API base URL",
-              "    Cloud:       https://api-na.myconnectwise.net (default)",
-              "                 https://api-eu.myconnectwise.net",
-              "                 https://api-au.myconnectwise.net",
-              "    Self-hosted: https://cwm.yourcompany.com",
-              "  CW_MANAGE_REJECT_UNAUTHORIZED - Set to 'false' for self-signed certs",
-            ].join("\n"),
-          },
-        ],
-        isError: true,
-      }),
-    );
-    return server;
-  }
-
-  const client = new CwManageClient(config);
-
-  registerTicketTools(server, client);
-  registerCompanyTools(server, client);
-  registerContactTools(server, client);
-  registerProjectTools(server, client);
-  registerTimeEntryTools(server, client);
-  registerMemberTools(server, client);
-  registerConfigurationTools(server, client);
-  registerServiceTools(server, client);
-  registerActivityTools(server, client);
-  registerCatalogTools(server, client);
-  registerHealthTools(server, client);
-  registerAgreementTools(server, client);
-  registerOpportunityTools(server, client);
-
-  return server;
-}
+import {
+  createMcpServer,
+  resolveGatewayConfig,
+  type CwManageConfig,
+} from "./mcp-server.js";
 
 // ---------------------------------------------------------------------------
 // Transport: stdio
@@ -315,20 +239,15 @@ async function startHttpTransport(): Promise<void> {
         }
 
         // ------------------------------------------------------------------
-        // Gateway mode: extract CW credentials from headers
+        // Gateway mode: extract CW credentials from headers (per request,
+        // no global process.env mutation so concurrent requests stay isolated)
         // ------------------------------------------------------------------
+        let configOverride: CwManageConfig | undefined;
         if (isGatewayMode) {
-          const headers = req.headers as Record<
-            string,
-            string | string[] | undefined
-          >;
-          const companyId = headers["x-cw-company-id"] as string | undefined;
-          const publicKey = headers["x-cw-public-key"] as string | undefined;
-          const privateKey = headers["x-cw-private-key"] as string | undefined;
-          const clientId = headers["x-cw-client-id"] as string | undefined;
-          const baseUrl = headers["x-cw-url"] as string | undefined;
-
-          if (!companyId || !publicKey || !privateKey || !clientId) {
+          const { config, error } = resolveGatewayConfig(
+            (name) => req.headers[name] as string | undefined,
+          );
+          if (error) {
             res.writeHead(401, { "Content-Type": "application/json" });
             res.end(
               JSON.stringify({
@@ -345,20 +264,13 @@ async function startHttpTransport(): Promise<void> {
             );
             return;
           }
-
-          process.env.CW_MANAGE_COMPANY_ID = companyId;
-          process.env.CW_MANAGE_PUBLIC_KEY = publicKey;
-          process.env.CW_MANAGE_PRIVATE_KEY = privateKey;
-          process.env.CW_MANAGE_CLIENT_ID = clientId;
-          if (baseUrl) {
-            process.env.CW_MANAGE_URL = baseUrl;
-          }
+          configOverride = config;
         }
 
         // ------------------------------------------------------------------
         // MCP handler
         // ------------------------------------------------------------------
-        const server = createMcpServer();
+        const server = createMcpServer(configOverride);
         const transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: undefined,
           enableJsonResponse: true,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,0 +1,156 @@
+/**
+ * Shared MCP server factory for ConnectWise Manage.
+ *
+ * This module is **side-effect free** (importing it never starts a transport),
+ * so it can be reused by every entrypoint:
+ * - `index.ts`  — stdio + Node HTTP transport
+ * - `worker.ts` — Cloudflare Workers (Web Standard) transport
+ *
+ * Credentials are resolved per request, in order:
+ * 1. An explicit `CwManageConfig` override (gateway mode / Workers headers).
+ * 2. `getConfig()` reading from `process.env` (env mode).
+ *
+ * `tools/list` and `initialize` work without credentials; when no config is
+ * available, only a single diagnostic `cw_test_connection` tool is registered,
+ * so credential-requiring calls fail with a clear, graceful message.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getConfig, CwManageClient, type CwManageConfig } from "./api-client.js";
+import { registerTicketTools } from "./tools/tickets.js";
+import { registerCompanyTools } from "./tools/companies.js";
+import { registerContactTools } from "./tools/contacts.js";
+import { registerProjectTools } from "./tools/projects.js";
+import { registerTimeEntryTools } from "./tools/time-entries.js";
+import { registerMemberTools } from "./tools/members.js";
+import { registerConfigurationTools } from "./tools/configurations.js";
+import { registerServiceTools } from "./tools/service.js";
+import { registerActivityTools } from "./tools/activities.js";
+import { registerCatalogTools } from "./tools/catalog.js";
+import { registerHealthTools } from "./tools/health.js";
+import { registerAgreementTools } from "./tools/agreements.js";
+import { registerOpportunityTools } from "./tools/opportunities.js";
+
+export type { CwManageConfig };
+
+/**
+ * Build a validated CwManageConfig from raw values.
+ * Returns `{ config }` on success or `{ error }` when required fields are
+ * missing. Shared by every transport (Node HTTP headers, Workers headers).
+ */
+export function buildConfig(
+  companyId: string | undefined,
+  publicKey: string | undefined,
+  privateKey: string | undefined,
+  clientId: string | undefined,
+  baseUrl?: string,
+): { config?: CwManageConfig; error?: string } {
+  if (!companyId || !publicKey || !privateKey || !clientId) {
+    return {
+      error:
+        "Missing credentials: X-CW-Company-Id, X-CW-Public-Key, X-CW-Private-Key, X-CW-Client-Id (or CW_MANAGE_* environment variables)",
+    };
+  }
+
+  const resolvedBaseUrl = (
+    baseUrl || "https://api-na.myconnectwise.net"
+  ).replace(/\/+$/, "");
+
+  return {
+    config: {
+      baseUrl: resolvedBaseUrl,
+      companyId,
+      publicKey,
+      privateKey,
+      clientId,
+    },
+  };
+}
+
+/**
+ * Resolve per-request gateway credentials from a header accessor.
+ *
+ * Works with any transport: pass a getter that returns a (lowercased) header
+ * value. Returns `{ config }` on success, or `{ error }` when required headers
+ * are missing.
+ */
+export function resolveGatewayConfig(
+  getHeader: (lowerName: string) => string | undefined,
+): { config?: CwManageConfig; error?: string } {
+  return buildConfig(
+    getHeader("x-cw-company-id"),
+    getHeader("x-cw-public-key"),
+    getHeader("x-cw-private-key"),
+    getHeader("x-cw-client-id"),
+    getHeader("x-cw-url"),
+  );
+}
+
+/**
+ * Create a fresh MCP server instance with all handlers registered.
+ * Called once for stdio, or per-request for HTTP / Workers transports.
+ *
+ * @param configOverride - Optional config (gateway mode / Workers headers).
+ *   When provided, the client is built from it instead of reading process.env.
+ */
+export function createMcpServer(configOverride?: CwManageConfig): McpServer {
+  const server = new McpServer({
+    name: "connectwise-manage-mcp",
+    version: "1.4.0",
+  });
+
+  const config = configOverride ?? getConfig();
+
+  if (!config) {
+    // Register a single diagnostic tool so the client gets a clear error
+    server.tool(
+      "cw_test_connection",
+      "Test the connection to ConnectWise Manage.",
+      {},
+      async () => ({
+        content: [
+          {
+            type: "text",
+            text: [
+              "Error: Missing ConnectWise Manage credentials.",
+              "",
+              "Required environment variables:",
+              "  CW_MANAGE_COMPANY_ID        - Your ConnectWise company identifier",
+              "  CW_MANAGE_PUBLIC_KEY        - API member public key",
+              "  CW_MANAGE_PRIVATE_KEY       - API member private key",
+              "  CW_MANAGE_CLIENT_ID         - Client ID from ConnectWise Developer Portal",
+              "",
+              "Optional:",
+              "  CW_MANAGE_URL               - API base URL",
+              "    Cloud:       https://api-na.myconnectwise.net (default)",
+              "                 https://api-eu.myconnectwise.net",
+              "                 https://api-au.myconnectwise.net",
+              "    Self-hosted: https://cwm.yourcompany.com",
+              "  CW_MANAGE_REJECT_UNAUTHORIZED - Set to 'false' for self-signed certs",
+            ].join("\n"),
+          },
+        ],
+        isError: true,
+      }),
+    );
+    return server;
+  }
+
+  const client = new CwManageClient(config);
+
+  registerTicketTools(server, client);
+  registerCompanyTools(server, client);
+  registerContactTools(server, client);
+  registerProjectTools(server, client);
+  registerTimeEntryTools(server, client);
+  registerMemberTools(server, client);
+  registerConfigurationTools(server, client);
+  registerServiceTools(server, client);
+  registerActivityTools(server, client);
+  registerCatalogTools(server, client);
+  registerHealthTools(server, client);
+  registerAgreementTools(server, client);
+  registerOpportunityTools(server, client);
+
+  return server;
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,142 @@
+/**
+ * Cloudflare Workers entry point for the ConnectWise Manage MCP Server.
+ *
+ * Serves the full MCP server over the Streamable HTTP transport using the SDK's
+ * Web Standard transport (Request/Response), which runs natively on Workers.
+ * It reuses the exact same `createMcpServer()` factory as the stdio / Node HTTP
+ * entrypoints (see `mcp-server.ts`), so there is no second tool implementation
+ * to maintain.
+ *
+ * Credentials are resolved per request, in order:
+ * 1. Gateway headers (when AUTH_MODE=gateway):
+ *    - X-CW-Company-Id
+ *    - X-CW-Public-Key
+ *    - X-CW-Private-Key
+ *    - X-CW-Client-Id
+ *    - X-CW-Url (optional)
+ * 2. Worker secrets / vars (env mode):
+ *    - CW_MANAGE_COMPANY_ID
+ *    - CW_MANAGE_PUBLIC_KEY
+ *    - CW_MANAGE_PRIVATE_KEY
+ *    - CW_MANAGE_CLIENT_ID
+ *    - CW_MANAGE_URL (optional)
+ *
+ * `tools/list` and `initialize` work without credentials; only `tools/call`
+ * requires them.
+ */
+
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import {
+  createMcpServer,
+  resolveGatewayConfig,
+  buildConfig,
+  type CwManageConfig,
+} from "./mcp-server.js";
+
+export interface Env {
+  CW_MANAGE_COMPANY_ID?: string;
+  CW_MANAGE_PUBLIC_KEY?: string;
+  CW_MANAGE_PRIVATE_KEY?: string;
+  CW_MANAGE_CLIENT_ID?: string;
+  CW_MANAGE_URL?: string;
+  AUTH_MODE?: string;
+  LOG_LEVEL?: string;
+}
+
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers":
+    "Content-Type, Accept, Authorization, Mcp-Session-Id, MCP-Protocol-Version, X-CW-Company-Id, X-CW-Public-Key, X-CW-Private-Key, X-CW-Client-Id, X-CW-Url",
+  "Access-Control-Expose-Headers": "Mcp-Session-Id",
+};
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+  });
+}
+
+function withCors(res: Response): Response {
+  const headers = new Headers(res.headers);
+  for (const [k, v] of Object.entries(CORS_HEADERS)) headers.set(k, v);
+  return new Response(res.body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+  });
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    // CORS preflight
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: CORS_HEADERS });
+    }
+
+    // Shallow, unauthenticated liveness probe.
+    if (url.pathname === "/health" || url.pathname === "/healthz") {
+      return json({ status: "ok" });
+    }
+
+    if (url.pathname === "/mcp") {
+      const isGatewayMode = (env.AUTH_MODE ?? "env") === "gateway";
+
+      let configOverride: CwManageConfig | undefined;
+      if (isGatewayMode) {
+        const { config, error } = resolveGatewayConfig(
+          (name) => request.headers.get(name) ?? undefined,
+        );
+        if (error) {
+          return json(
+            {
+              error: "Missing credentials",
+              message: error,
+              required: [
+                "X-CW-Company-Id",
+                "X-CW-Public-Key",
+                "X-CW-Private-Key",
+                "X-CW-Client-Id",
+              ],
+              optional: ["X-CW-Url"],
+            },
+            401,
+          );
+        }
+        configOverride = config;
+      } else {
+        // env mode: build config from Worker secrets if present.
+        // (Absent creds are fine — tools/list still works, tools/call errors.)
+        const { config } = buildConfig(
+          env.CW_MANAGE_COMPANY_ID,
+          env.CW_MANAGE_PUBLIC_KEY,
+          env.CW_MANAGE_PRIVATE_KEY,
+          env.CW_MANAGE_CLIENT_ID,
+          env.CW_MANAGE_URL,
+        );
+        configOverride = config;
+      }
+
+      // Fresh server + transport per request (stateless).
+      const server = createMcpServer(configOverride);
+      const transport = new WebStandardStreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true,
+      });
+      await server.connect(transport);
+
+      try {
+        const response = await transport.handleRequest(request);
+        return withCors(response);
+      } finally {
+        await transport.close();
+        await server.close();
+      }
+    }
+
+    return json({ error: "Not found", endpoints: ["/mcp", "/health"] }, 404);
+  },
+};

--- a/wrangler.json
+++ b/wrangler.json
@@ -1,6 +1,6 @@
 {
   "name": "connectwise-manage-mcp",
-  "main": "dist/worker.js",
+  "main": "src/worker.ts",
   "compatibility_date": "2026-02-01",
   "compatibility_flags": ["nodejs_compat"],
   "vars": {


### PR DESCRIPTION
## Context

Part of a fleet-wide pass over the MCP-server repos that advertise one-click **Deploy to Cloudflare Workers** / **Deploy to DigitalOcean** buttons. The known bug: when a repo depends on a private `@wyre-technology/node-<vendor>` SDK (hosted on GitHub Packages, which requires a token on every install), the cloud builder's `npm install` fails with `401 Unauthorized`. The proven fix (ninjaone-mcp PR #35) adds an `.npmrc` redirect + build-var token.

## Finding for this repo

**connectwise-manage-mcp does NOT depend on any `@wyre-technology/*` package.** Its only runtime deps are `@modelcontextprotocol/sdk` and `jose` — both public on the npmjs registry. The cloud builders install these anonymously, so **the deploy buttons already work and no `.npmrc` auth fix is needed here.**

Verified locally: `npm ci`, `npm run build`, `npm run lint` (0 errors), `npm test` (10 passing) all green.

## What this PR does (per the fleet directive that all servers publish to GitHub Packages)

- **`.releaserc.json`** — `@semantic-release/npm` `npmPublish: false → true`.
- **`package.json`** — add `publishConfig.registry = https://npm.pkg.github.com`.
- **`README.md`** — clarify that one-click deploy needs no token, and that installing the *published* package from GitHub Packages requires a GitHub PAT with `read:packages` (`export NODE_AUTH_TOKEN=$(gh auth token)`).
- **`CHANGELOG.md`** — `## [Unreleased]` entries (keepachangelog 1.1.0).

## Anomaly noted

`wrangler.json` sets `main: dist/worker.js`, but there is **no `src/worker.ts`** (and no build step emits `dist/worker.js`). The Cloudflare Workers button would therefore fail at runtime regardless of registry auth — there is no Workers entrypoint. Out of scope for this PR; flagging for follow-up.

Do not merge without review.