### PR TITLE
docs: Update README with tools and correct tool count

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Let your AI assistant work directly with ConnectWise Manage.** Search tickets, log time, look up companies and contacts, manage projects — through natural conversation instead of clicking through the CWM interface.
 
-This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that gives Claude (or any MCP-compatible AI) 34 tools covering the daily operations ConnectWise Manage shops depend on. Works with both **cloud-hosted and self-hosted** CWM instances — just point it at your server.
+This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that gives Claude (or any MCP-compatible AI) 51 tools covering the daily operations ConnectWise Manage shops depend on. Works with both **cloud-hosted and self-hosted** CWM instances — just point it at your server.
 
 > **Part of the [MSP Claude Plugins](https://github.com/wyre-technology/msp-claude-plugins) ecosystem** — a growing suite of AI integrations for the MSP stack including [Autotask](https://github.com/wyre-technology/autotask-mcp), [Datto RMM](https://github.com/wyre-technology/datto-rmm-mcp), [IT Glue](https://github.com/wyre-technology/itglue-mcp), [HaloPSA](https://github.com/wyre-technology/halopsa-mcp), [NinjaOne](https://github.com/wyre-technology/ninjaone-mcp), [Huntress](https://github.com/wyre-technology/huntress-mcp), and more. Built by MSPs, for MSPs.
 
@@ -115,6 +115,31 @@ If your self-hosted instance uses a self-signed certificate, also set `CW_MANAGE
 - `cw_search_activities` — Search activities
 - `cw_get_activity` — Get an activity by ID
 - `cw_create_activity` — Create a new activity
+
+### Agreements
+- `cw_search_agreements` — Search agreements
+- `cw_get_agreement` — Get an agreement by ID
+- `cw_get_agreement_additions` — Get additions (line items) on an agreement
+
+### Invoices
+- `cw_search_invoices` — Search invoices
+- `cw_get_invoice` — Get an invoice by ID
+
+### Opportunities
+- `cw_search_opportunities` — Search opportunities
+- `cw_get_opportunity` — Get an opportunity by ID
+- `cw_search_opportunity_forecasts` — Search opportunity forecast lines
+- `cw_search_opportunity_notes` — Search notes on an opportunity
+- `cw_search_sales_stages` — List sales pipeline stages
+
+### Catalog (Products)
+- `cw_search_catalog_items` — Search product catalog items
+- `cw_get_catalog_item` — Get a catalog item by ID
+- `cw_create_catalog_item` — Create a new catalog item
+- `cw_update_catalog_item` — Update a catalog item (JSON Patch)
+- `cw_list_catalog_categories` — List catalog categories
+- `cw_list_catalog_subcategories` — List catalog subcategories
+- `cw_list_manufacturers` — List manufacturers
 
 ### Health
 - `cw_test_connection` — Test connection (hits `/system/info`)


### PR DESCRIPTION
This pull request updates the documentation to reflect the addition of several new tools to the MCP server, increasing the total from 34 to 51. The `README.md` now includes detailed descriptions of the new tools, grouped by functionality, such as Agreements, Invoices, Opportunities, and Catalog (Products).

New tool documentation:

* Agreements:
  - Added documentation for searching agreements, retrieving an agreement by ID, and getting agreement additions.
* Invoices:
  - Added documentation for searching invoices and retrieving an invoice by ID.
* Opportunities:
  - Added documentation for searching opportunities, retrieving an opportunity by ID, searching opportunity forecast lines, searching opportunity notes, and listing sales pipeline stages.
* Catalog (Products):
  - Added documentation for searching catalog items, retrieving a catalog item by ID, creating and updating catalog items, and listing catalog categories, subcategories, and manufacturers.

General documentation update:

* Updated the tool count in the introduction from 34 to 51 to reflect the expanded capabilities.