### PR TITLE
ci: centralize release pipeline via reusable mcp-server-release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,191 +6,37 @@ on:
   pull_request:
     branches: [main]
 
+# Thin caller for the canonical reusable release pipeline. The build →
+# semantic-release → Docker → MCP Registry → security chain (tag-based release
+# detection + correct gating) lives in wyre-technology/.github so every *-mcp
+# repo stays in lockstep instead of drifting per-repo. PR-time lint/test gating
+# is each repo's ci.yml concern; this workflow only runs the release path.
+# Caller jobs grant the token scopes the reusable jobs request (a reusable can
+# only reduce, never expand, caller-granted scope).
 jobs:
-  test:
-    name: Test
-    # Delegated to the canonical reusable CI workflow.
-    # See: ~/.claude/skills/mcp-server-fleet-ci-template
-    uses: wyre-technology/.github/.github/workflows/mcp-server-ci.yml@198605d0575e27374cf9b67fba3aa8c7b91de2c0
-    with:
-      node-versions: '["20", "22"]'
-    secrets: inherit
-
   release:
-    name: Release
-    runs-on: ubuntu-latest
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
       issues: write
       packages: write
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-      released: ${{ steps.version.outputs.released }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-      - run: npm ci
-      - run: npm run build
-      - name: Capture pre-release version
-        run: |
-          PRE_VERSION=$(node -p "require('./package.json').version")
-          echo "PRE_VERSION=$PRE_VERSION" >> "$GITHUB_ENV"
-
-      - name: Semantic Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
-
-      - name: Get released version
-        id: version
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          if [ "$VERSION" != "$PRE_VERSION" ]; then
-            echo "released=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "released=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Pack and upload MCPB bundle
-        if: steps.version.outputs.released == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          BUNDLE_NAME=$(node -p "require('./package.json').name.replace(/^@.*\//, '')")
-          npm install -g @anthropic-ai/mcpb
-          npm run pack:mcpb
-          echo "Looking for bundle file..."
-          ls -la *.mcpb 2>/dev/null || true
-          gh release upload "v${{ steps.version.outputs.version }}" "${BUNDLE_NAME}.mcpb" \
-            --repo ${{ github.repository }} --clobber
-
-      - name: Discord release notification
-        if: false  # disabled - too noisy, re-enable later
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          BODY=$(gh release view "v$VERSION" --json body --jq '.body' 2>/dev/null || echo "")
-          SUMMARY=$(echo "$BODY" | sed '1,2d' | head -30 | cut -c1-1800)
-          DESC="**${{ github.repository }}** — [v${VERSION}](https://github.com/${{ github.repository }}/releases/tag/v${VERSION})"$'\n'"${SUMMARY}"
-          PAYLOAD=$(jq -n --arg title "New Release: v${VERSION}" --arg desc "$DESC" '{embeds: [{title: $title, description: $desc, color: 5763847}]}')
-          curl -sf -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK"
-  docker:
-    name: Docker
-    runs-on: ubuntu-latest
-    needs: [release]
-    # Gate on an actual semantic-release. A non-release push to main would
-    # otherwise rebuild and re-push :latest tagged with the stale package.json
-    # version, clobbering the correctly-tagged :latest from the last real
-    # release. Skipping docker cascades to deploy/registry (skipped dependency).
-    if: needs.release.outputs.released == 'true'
-    permissions:
-      contents: read
-      packages: write
-    outputs:
-      digest: ${{ steps.push.outputs.digest }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - name: Login to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
-      - name: Resolve release version
-        id: version
-        env:
-          RELEASE_VERSION: ${{ needs.release.outputs.version }}
-        run: |
-          if [ -z "$RELEASE_VERSION" ]; then
-            echo "ERROR: needs.release.outputs.version is empty" >&2
-            exit 1
-          fi
-          echo "version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
-      - name: Build and push
-        id: push
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:v${{ steps.version.outputs.version }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-  mcp-registry:
-    name: Publish to MCP Registry
-    runs-on: ubuntu-latest
-    needs: [release, docker]
-    if: needs.release.outputs.released == 'true'
-    permissions:
       id-token: write
-      contents: read
-    env:
-      VERSION: ${{ needs.release.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
-      - name: Install mcp-publisher
-        run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
-            | tar xz mcp-publisher
-      - name: Stamp version into server.json
-        run: |
-          jq --arg v "$VERSION" \
-            '.version = $v | .packages[0].identifier = "ghcr.io/wyre-technology/connectwise-manage-mcp:v" + $v' \
-            server.json > server.json.tmp
-          mv server.json.tmp server.json
-          cat server.json
-      - name: Validate server.json
-        run: ./mcp-publisher validate
-      - name: Authenticate to MCP Registry (GitHub OIDC)
-        run: ./mcp-publisher login github-oidc
-      - name: Publish to MCP Registry
-        run: ./mcp-publisher publish
-      - name: Verify registry listing
-        run: |
-          sleep 5
-          curl -sf "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.wyre-technology/connectwise-manage-mcp" \
-            | jq '.servers[]?.server | {name, version}'
+      security-events: write
+    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@7794e75666ac4956274f7a7d25dabacd56c96bbc
+    with:
+      server-name: connectwise-manage-mcp
+      image-name: ghcr.io/wyre-technology/connectwise-manage-mcp
+    secrets: inherit
 
   deploy:
-    name: Deploy to Azure Container Apps
-    needs: [release, docker]
+    needs: release
     if: needs.release.outputs.released == 'true'
     permissions:
       id-token: write
       contents: read
-    uses: wyre-technology/.github/.github/workflows/mcp-server-deploy.yml@198605d0575e27374cf9b67fba3aa8c7b91de2c0
+    uses: wyre-technology/.github/.github/workflows/mcp-server-deploy.yml@7794e75666ac4956274f7a7d25dabacd56c96bbc
     with:
       vendor-slug: connectwise-manage
       image-name: ghcr.io/wyre-technology/connectwise-manage-mcp
-      digest: ${{ needs.docker.outputs.digest }}
+      digest: ${{ needs.release.outputs.digest }}
       version: ${{ needs.release.outputs.version }}
     secrets: inherit


### PR DESCRIPTION
Replaces the inline release/docker/mcp-registry/deploy jobs with a thin caller of the reusable workflows in wyre-technology/.github (release via mcp-server-release.yml, deploy via mcp-server-deploy.yml). Fixes the 'duplicate version' MCP Registry failure from the old gh-release-view gating; release detection is now tag-based. Proven on domotz-mcp#27. Part of the fleet-wide centralization. vendor-slug=connectwise-manage.