### PR TITLE
ci(deps): ignore typescript major-version bumps in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,15 @@ updates:
         update-types: ["minor", "patch"]
     # Production MAJORS are intentionally NOT grouped → individual PRs, held for
     # human review (never auto-merged).
+    ignore:
+      # typescript 7.x breaks this fleet's toolchain: DTS emit (tsup/rollup-plugin-dts
+      # TS5101 baseUrl-deprecated-as-error), and typescript-eslint (still <6.1.0 as of
+      # 8.66.0, no TS7 support yet). Has broken main 3x on some repos because Dependabot
+      # has no memory of a prior manual revert and just re-proposes the same major again.
+      # Deliberate hold, not a permanent blind -- remove once typescript-eslint + the
+      # tsup/DTS toolchain support TS7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

Adds an `ignore:` rule to the npm `updates:` entry in `.github/dependabot.yml` so Dependabot stops proposing `typescript` MAJOR-version bumps on this repo, until the fleets toolchain catches up.

## Why

typescript 7.x breaks this fleets toolchain:
- DTS emit via tsup/rollup-plugin-dts throws `TS5101` ("baseUrl deprecated") as a hard error.
- `typescript-eslint` still caps its peer range below typescript 6.1.0 as of its latest 8.66.0 release -- no TS7 support yet.

Several repos in the `wyre-technology` org have already had this manually fixed once (typescript pinned back down) only to have Dependabot re-propose and re-merge the exact same breaking major bump later, because Dependabot has no memory of a prior manual revert. This broke `main` on 5 repos as recently as tonight.

This is a deliberate, temporary hold (not a permanent blind) -- the ignore rule should be removed once `typescript-eslint` and the tsup/DTS toolchain support TS7. `typescript` minor and patch updates are unaffected and continue to flow through the existing `dev-dependencies` group as before.

## Test plan

- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(open(...))"`
- [x] `git diff` confirms only the intended 9-line `ignore:` block was added, nothing else changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/connectwise-manage-mcp/pr/63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->