### PR TITLE
fix(ci): restore connectwise-manage-mcp.mcpb as a release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       packages: write
       id-token: write
       security-events: write
-    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@8deff2993e933c45856861cb3491d251361a5a8a
+    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@8bfc9b3a249fd1e6f69f1d05c45c8eaf3076fec3
     with:
       server-name: connectwise-manage-mcp
       image-name: ghcr.io/wyre-technology/connectwise-manage-mcp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       packages: write
       id-token: write
       security-events: write
-    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@d28a612a00a1bd0c36aff09e686ce2d1e10ef552
+    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@8deff2993e933c45856861cb3491d251361a5a8a
     with:
       server-name: connectwise-manage-mcp
       image-name: ghcr.io/wyre-technology/connectwise-manage-mcp


### PR DESCRIPTION
Restores the Claude Desktop `.mcpb` bundle to this repo's GitHub releases. Fleet-wide fix tracked from [autotask-mcp#244](https://github.com/wyre-technology/autotask-mcp/issues/244).

## Problem

The hand-rolled per-repo release workflows that `mcp-server-release.yml` replaced each carried a **"Pack and upload MCPB bundle"** step (`npm run pack:mcpb` + `gh release upload`). It was never carried over into the shared workflow, so every repo that migrated silently stopped attaching its bundle — while READMEs still tell users to download it.

**25 of the 26 repos with a `pack:mcpb` script publish releases with zero assets.** This repo is one of them.

## Fix

Bumps the `mcp-server-release.yml` pin `d28a612` → `8deff29`. The shared workflow now has an `mcpb` job, auto-detected from the presence of a `pack:mcpb` script — so no caller changes are needed beyond this one-line pin bump.

The job `needs` only `release`, never `docker`, so a pack failure cannot cascade into skipping the Docker/registry/deploy chain.

## Pin range (diffed before bumping)

```
git log d28a612..8deff29 -- .github/workflows/mcp-server-release.yml
8deff29 fix(release): accept lowercase `config` in the digest verify check (#46)
3b76ae0 fix(release): use .Image.Config in the digest verify template (#45)
ebbdf5a fix(release): pack and upload the .mcpb bundle as a release asset (#43)
0e04141 fix(mcp-server-release): pin provenance:false + verify digest (#40)
```

Net effect: **one new `mcpb` job**, plus #40's `provenance: false` + digest-verification hardening on the `docker` job.

Worth stating plainly: #40 shipped a digest-verify step that had never actually executed anywhere, and it contained two bugs that blocked `autotask-mcp`'s deploy twice (an invalid `--format` template, then a `Config`/`config` casing error). Both are fixed in #45 and #46, which are included in this pin. **This exact combination has since run green end-to-end — build, bundle, registry publish, security scan and deploy — three consecutive times on autotask-mcp: v2.32.7, v2.32.8, v2.32.9.**

## Risk

Workflow-only; no runtime code touched. First release after merge should carry `connectwise-manage-mcp.mcpb` as a release asset.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/connectwise-manage-mcp/pr/66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->