### PR TITLE
fix(lint): promote no-unused-vars + no-explicit-any back to error (Mode-4 debt cleared)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,10 +14,8 @@ export default tseslint.config(
       globals: { ...globals.node },
     },
     rules: {
-      // Preserved from prior .eslintrc.cjs (Mode-4 warn-baseline): these two rules are
-      // intentionally downgraded error -> warn to preserve latent lint debt without blocking.
-      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
-      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-explicit-any': 'error',
     },
   },
 );

--- a/src/auth/middleware.test.ts
+++ b/src/auth/middleware.test.ts
@@ -18,6 +18,8 @@ vi.mock("jose", async () => {
 
 import { jwtVerify } from "jose";
 
+type MockJwtVerifyResult = Awaited<ReturnType<typeof jwtVerify>>;
+
 // ---------------------------------------------------------------------------
 // Shared test config
 // ---------------------------------------------------------------------------
@@ -58,8 +60,8 @@ describe("validateToken", () => {
         sub: "test-sub",
       },
       protectedHeader: { alg: "RS256" },
-      key: {} as any,
-    } as any);
+      key: {} as unknown as MockJwtVerifyResult["key"],
+    } as unknown as MockJwtVerifyResult);
 
     const identity = await validateToken("valid-token", config, mockJwks);
 
@@ -84,8 +86,8 @@ describe("validateToken", () => {
         sub: "test-sub",
       },
       protectedHeader: { alg: "RS256" },
-      key: {} as any,
-    } as any);
+      key: {} as unknown as MockJwtVerifyResult["key"],
+    } as unknown as MockJwtVerifyResult);
 
     await expect(validateToken("valid-token", config, mockJwks)).rejects.toMatchObject({
       statusCode: 401,
@@ -108,8 +110,8 @@ describe("validateToken", () => {
         sub: "test-sub",
       },
       protectedHeader: { alg: "RS256" },
-      key: {} as any,
-    } as any);
+      key: {} as unknown as MockJwtVerifyResult["key"],
+    } as unknown as MockJwtVerifyResult);
 
     const error = await validateToken("valid-token", config, mockJwks).catch((e) => e);
     expect(error).toBeInstanceOf(AuthError);
@@ -126,7 +128,6 @@ describe("validateToken", () => {
   });
 
   it("propagates AuthError immediately without retrying other audiences", async () => {
-    const authErr = new AuthError("Access denied: missing required role 'CWM.Access'", 403);
     vi.mocked(jwtVerify).mockResolvedValueOnce({
       payload: {
         tid: "test-tenant-id",
@@ -140,8 +141,8 @@ describe("validateToken", () => {
         sub: "sub",
       },
       protectedHeader: { alg: "RS256" },
-      key: {} as any,
-    } as any);
+      key: {} as unknown as MockJwtVerifyResult["key"],
+    } as unknown as MockJwtVerifyResult);
 
     const error = await validateToken("bad-role-token", config, mockJwks).catch((e) => e);
     expect(error).toBeInstanceOf(AuthError);


### PR DESCRIPTION
## What
Restores `@typescript-eslint/no-unused-vars` and `@typescript-eslint/no-explicit-any` from `warn` back to `error`, matching the rest of the fleet-canonical eslint config.

## Why
Fixed all 9 latent findings this warn-downgrade existed for, all in `src/auth/middleware.test.ts`:
- 8x `as any` on `jwtVerify` mock return values -> replaced with a typed `Awaited<ReturnType<typeof jwtVerify>>` alias (same idiom the file already used for `mockJwks` two lines up).
- 1x genuinely unused `authErr` variable -> removed.

## Test plan
- [x] `npm run lint` (== CI's `eslint src`) exits 0
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/auth/middleware.test.ts` -- 10/10 passing

cortextos task_1779394868097_72147253

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/connectwise-manage-mcp/pr/67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->