### PR TITLE
fix(manifest): correct Base URL env var name (CW_MANAGE_BASE_URL -> CW_MANAGE_URL)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
     "mcp_config": {
       "command": "node",
       "args": ["${__dirname}/dist/index.js"],
-      "env": { "CW_MANAGE_COMPANY_ID": "${user_config.cw_manage_company_id}", "CW_MANAGE_PUBLIC_KEY": "${user_config.cw_manage_public_key}", "CW_MANAGE_PRIVATE_KEY": "${user_config.cw_manage_private_key}", "CW_MANAGE_CLIENT_ID": "${user_config.cw_manage_client_id}", "CW_MANAGE_BASE_URL": "${user_config.cw_manage_base_url}", "MCP_TRANSPORT": "stdio" }
+      "env": { "CW_MANAGE_COMPANY_ID": "${user_config.cw_manage_company_id}", "CW_MANAGE_PUBLIC_KEY": "${user_config.cw_manage_public_key}", "CW_MANAGE_PRIVATE_KEY": "${user_config.cw_manage_private_key}", "CW_MANAGE_CLIENT_ID": "${user_config.cw_manage_client_id}", "CW_MANAGE_URL": "${user_config.cw_manage_base_url}", "MCP_TRANSPORT": "stdio" }
     }
   },
   "tools_generated": true,


### PR DESCRIPTION
## Summary
`manifest.json` mapped the user-configured Base URL to the environment variable `CW_MANAGE_BASE_URL`, but `src/api-client.ts` (and `src/mcp-server.ts`'s help text) read `CW_MANAGE_URL`. The Base URL field in the plugin UI was silently ignored — the server always fell back to the default `https://api-na.myconnectwise.net`, breaking non-NA tenants (e.g. AU) with a misleading `400: Invalid Token`.

## Change
One-line env-key fix in `manifest.json`'s `mcp_config.env`: `CW_MANAGE_BASE_URL` -> `CW_MANAGE_URL`. The `user_config` key (`cw_manage_base_url`) is left as-is — renaming it would be a breaking change for existing installs, which is out of scope here.

## Test plan
- [x] `mcpb validate manifest.json` — schema validation passes
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 98/98 pass

Fixes #48

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WYRE-AI/codesmith/connectwise-manage-mcp/pr/72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790469904&installation_model_id=431408&pr_number=72&repository=WYRE-AI%2Fconnectwise-manage-mcp&return_to=https%3A%2F%2Fgithub.com%2FWYRE-AI%2Fconnectwise-manage-mcp%2Fpull%2F72&signature=d52d7c2f5ea95e08a50ceb4d6be5938889c019a0ab6ee48386f1f3c43c3a14cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->