### PR TITLE
ci: bump wyre-technology/.github add-to-project pin

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   call:
-    uses: wyre-technology/.github/.github/workflows/auto-add-to-project.yml@c3314c1065f78adf905a815ad214c71266913771  # pinned (warden C-4) — bump via PR not in-place edit
+    uses: wyre-technology/.github/.github/workflows/auto-add-to-project.yml@692c0d01979dfe2a2738d71dbf20a3b47a3bb014  # pinned (warden C-4) — bump via PR not in-place edit
     secrets: inherit


### PR DESCRIPTION
Routine pin bump, no functional change to this file.

Byte-for-byte verified identical content at both shas (warden, independent check): `wyre-technology/.github`'s `auto-add-to-project.yml` was last actually edited by `17f37d1f7f1e` (2026-08-13, #44 — stops the workflow hard-failing on Dependabot PRs), which is an ancestor of both the old pin and this one. Picks up 15 days of unrelated main-branch drift only (the pin comment says "bump via PR not in-place edit" — this is that bump).

Part of a 29-repo class sweep (same shape as Friday's cosign/sigstore pin-bump). Not for individual merge — bundled as one class-ask, gated on Aaron's go per boss's ruling.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WYRE-AI/codesmith/connectwise-manage-mcp/pr/74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790724591&installation_model_id=431408&pr_number=74&repository=WYRE-AI%2Fconnectwise-manage-mcp&return_to=https%3A%2F%2Fgithub.com%2FWYRE-AI%2Fconnectwise-manage-mcp%2Fpull%2F74&signature=1d778fda3dda78f050d95b51826e1d721f53b8133357e9c6fe3bd862e0b4869a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automation workflow used to add items to a project, keeping it aligned with the latest supported workflow version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->