### PR TITLE
ci: repoint reusable release workflow to public WYRE-AI/reusable-workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 # Thin caller for the canonical reusable release pipeline. The build →
 # semantic-release → Docker → MCP Registry → security chain (tag-based release
-# detection + correct gating) lives in WYRE-AI/.github so every *-mcp
+# detection + correct gating) lives in the public WYRE-AI/reusable-workflows repo so every *-mcp
 # repo stays in lockstep instead of drifting per-repo. PR-time lint/test gating
 # is each repo's ci.yml concern; this workflow only runs the release path.
 # Caller jobs grant the token scopes the reusable jobs request (a reusable can
@@ -22,7 +22,7 @@ jobs:
       packages: write
       id-token: write
       security-events: write
-    uses: WYRE-AI/.github/.github/workflows/mcp-server-release.yml@8c2360058e882a8afacfc4cebf840135789ef406
+    uses: WYRE-AI/reusable-workflows/.github/workflows/mcp-server-release.yml@2b0b056bd7544937e5cbd56cf2e1ff8a180a411f
     with:
       server-name: connectwise-manage-mcp
       image-name: ghcr.io/wyre-ai/connectwise-manage-mcp
@@ -44,7 +44,7 @@ jobs:
   #   permissions:
   #     id-token: write
   #     contents: read
-  #   uses: WYRE-AI/.github/.github/workflows/mcp-server-deploy.yml@8c2360058e882a8afacfc4cebf840135789ef406
+  #   uses: WYRE-AI/reusable-workflows/.github/workflows/mcp-server-deploy.yml@2b0b056bd7544937e5cbd56cf2e1ff8a180a411f
   #   with:
   #     vendor-slug: connectwise-manage
   #     image-name: ghcr.io/wyre-ai/connectwise-manage-mcp


### PR DESCRIPTION
Public repos cannot call reusable workflows hosted in a private repo — GitHub fails the run with `workflow was not found` before any job is scheduled. The fleet canonical `mcp-server-release.yml` moved into the private `WYRE-AI/.github` during the org migration, breaking `release.yml` fleet-wide. The reusable workflows now live in the public [`WYRE-AI/reusable-workflows`](https://github.com/WYRE-AI/reusable-workflows) (content audited; predecessors already public in `wyre-technology/.github`). Same fix as the verified pilot WYRE-AI/datto-rmm-mcp#81.

https://claude.ai/code/session_01YRDJ5iRqpkar7tXqUsV8Zq

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WYRE-AI/codesmith/connectwise-manage-mcp/pr/77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791032569&installation_model_id=431408&pr_number=77&repository=WYRE-AI%2Fconnectwise-manage-mcp&return_to=https%3A%2F%2Fgithub.com%2FWYRE-AI%2Fconnectwise-manage-mcp%2Fpull%2F77&signature=109b7da76c96f7c71d77b2c03762cedfb43f9dce5ea5cac3c9922ea94cdc6f6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->